### PR TITLE
Issue 116: add core to notify path converter

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-10-06 Jan Kotanski <jan.kotanski@desy.de>
+	* add use_corepath_as_scandir into the configuration variables (#117)
+	* tagged as 0.0.6
+
 2021-09-30 Jan Kotanski <jan.kotanski@desy.de>
 	* add rechecking beamtime files if exists (#100)
 	* change {bt} format keyword to {beamtimeid} keyword (#104)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The configuration written in YAML can contain the following variables
 * **scan_metadata_postfix** *(str)* , default: `".scan.json"`
 * **datablock_metadata_postfix** *(str)* , default: `".origdatablock.json"`
 * **metadata_in_log_dir** *(bool)* , default: `False`
+* **use_corepath_as_scandir** *(bool)* , default: `False`
 * **beamtime_filename_postfix** *(str)* , default: `"beamtime-metadata-"`
 * **beamtime_filename_prefix** *(str)* , default: `".json"`
 * **datasets_filename_pattern** *(str)* , default: `"scicat-datasets-{beamtimeid}.lst"`

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -61,6 +61,7 @@ The configuration written in YAML can contain the following variables
 * **scan_metadata_postfix** *(str)* , default: ``".scan.json"``
 * **datablock_metadata_postfix** *(str)* , default: ``".origdatablock.json"``
 * **metadata_in_log_dir** *(bool)* , default: ``False``
+* **use_corepath_as_scandir** *(bool)* , default: ``False``
 * **beamtime_filename_postfix** *(str)* , default: ``"beamtime-metadata-"``
 * **beamtime_filename_prefix** *(str)* , default: ``".json"``
 * **datasets_filename_pattern** *(str)* , default: ``"scicat-datasets-{beamtimeid}.lst"``

--- a/scingestor/__init__.py
+++ b/scingestor/__init__.py
@@ -20,4 +20,4 @@
 #
 
 #: (:obj:`str`) the scingestor version
-__version__ = "0.0.5"
+__version__ = "0.0.6"

--- a/scingestor/datasetIngest.py
+++ b/scingestor/datasetIngest.py
@@ -26,6 +26,7 @@ import json
 
 from .configuration import load_config
 from .datasetIngestor import DatasetIngestor
+from .pathConverter import PathConverter
 from .logger import get_logger, init_logger
 
 
@@ -45,6 +46,15 @@ class DatasetIngest:
         if options.config:
             self.__config = load_config(options.config) or {}
             get_logger().debug("CONFIGURATION: %s" % str(self.__config))
+
+        #: (:obj:`bool`) use core path
+        self.__usecorepath = False
+        if "use_corepath_as_scandir" in self.__config.keys():
+            try:
+                self.__usecorepath = bool(
+                    self.__config["use_corepath_as_scandir"])
+            except Exception as e:
+                get_logger().warning('%s' % (str(e)))
 
         #: (:obj:`list` <:obj:`str`>) beamtime directories
         self.__beamtime_dirs = [
@@ -135,6 +145,18 @@ class DatasetIngest:
         #: (:obj:`str`) beamtime id
         beamtimeId = meta["beamtimeId"]
 
+        #: (:obj:`str`) core path
+        corepath = meta.get("corePath", None)
+
+        #: (:obj:`str`) beamtime path
+        bpath = os.path.split(beamtimefile)[0]
+
+        conv = PathConverter(
+            corepath, bpath,
+            self.__usecorepath and corepath)
+
+        path = conv.to_core(path)
+
         #: (:obj:`str`) datasets file name
         dslist_filename = self.__ds_pattern.format(beamtimeid=beamtimeId)
         #: (:obj:`str`) ingescted datasets file name
@@ -153,7 +175,7 @@ class DatasetIngest:
             scpath, pfn = os.path.split(fn)
             ingestor = DatasetIngestor(
                 self.__config,
-                scpath, fn, ifn, meta, beamtimefile)
+                scpath, fn, ifn, meta, conv.to_core(beamtimefile))
             if self.__groups_from_proposal and \
                ("accessGroups" not in meta or "ownerGroup" not in meta):
                 meta = ingestor.append_proposal_groups()

--- a/scingestor/datasetIngest.py
+++ b/scingestor/datasetIngest.py
@@ -122,22 +122,16 @@ class DatasetIngest:
                     get_logger().warning(
                         "%s cannot be ingested: %s" % (ffn, str(e)))
 
-    def _ingest_scandir(self, path, meta, bpath):
+    def _ingest_scandir(self, path, meta, beamtimefile):
         """ constructor
 
         :param path: scan dir path
         :type path: :obj:`str`
         :param meta: beamtime configuration
         :type meta: :obj:`dict` <:obj:`str`, `any`>
-        :param bpath: beamtime file
-        :type bpath: :obj:`str`
+        :param beamtimefile: beamtime file
+        :type beamtimefile: :obj:`str`
         """
-        # #: (:obj:`str`) scan dir path
-        # self.__path = path
-        # #: (:obj:`str`) beamtime path and file name
-        # self.__bpath = bpath
-        # #: (:obj:`dict` <:obj:`str`, `any`>) beamtime configuration
-        # self.__meta = meta
         #: (:obj:`str`) beamtime id
         beamtimeId = meta["beamtimeId"]
 
@@ -159,7 +153,7 @@ class DatasetIngest:
             scpath, pfn = os.path.split(fn)
             ingestor = DatasetIngestor(
                 self.__config,
-                scpath, fn, ifn, meta, bpath)
+                scpath, fn, ifn, meta, beamtimefile)
             if self.__groups_from_proposal and \
                ("accessGroups" not in meta or "ownerGroup" not in meta):
                 meta = ingestor.append_proposal_groups()

--- a/scingestor/datasetIngestor.py
+++ b/scingestor/datasetIngestor.py
@@ -32,14 +32,15 @@ class UpdateStrategy(enum.Enum):
 
     """ Update strategy
     """
-    #: (:class:`datasetIngestor.UpdateStrategy`) leave datasets unchanged
+    #: (:class:`scingestor.datasetIngestor.UpdateStrategy`)
+    #:       leave datasets unchanged
     NO = 0
-    #: (:class:`datasetIngestor.UpdateStrategy`) patch datasets
+    #: (:class:`scingestor.datasetIngestor.UpdateStrategy`) patch datasets
     PATCH = 1
-    #: (:class:`datasetIngestor.UpdateStrategy`) recreate datasets
+    #: (:class:`scingestor.datasetIngestor.UpdateStrategy`) recreate datasets
     CREATE = 2
-    #: (:class:`datasetIngestor.UpdateStrategy`) patch datasets only if
-    #:       scientificMetadata changed otherwise recreate datasets
+    #: (:class:`scingestor.datasetIngestor.UpdateStrategy`) patch datasets only
+    #:       if scientificMetadata changed otherwise recreate datasets
     MIXED = 3
 
 

--- a/scingestor/datasetWatcher.py
+++ b/scingestor/datasetWatcher.py
@@ -78,8 +78,8 @@ class DatasetWatcher(threading.Thread):
                 get_logger().warning('%s' % (str(e)))
 
         self.__conv = PathConverter(
-            self.__corepath, self._bpath,
-            self.__usecorepath and self.__corePath)
+            self.__corepath, self.__bpath,
+            self.__usecorepath and self.__corepath)
 
         #: (:obj:`str`) file with a dataset list
         self.__dsfile = dsfile

--- a/scingestor/datasetWatcher.py
+++ b/scingestor/datasetWatcher.py
@@ -102,7 +102,7 @@ class DatasetWatcher(threading.Thread):
     def _start_notifier(self, path):
         """ start notifier
 
-        :param path: beamtime file subpath
+        :param path: beamtime file sub directory
         :type path: :obj:`str`
         """
         self.__notifier = SafeINotifier()

--- a/scingestor/datasetWatcher.py
+++ b/scingestor/datasetWatcher.py
@@ -25,6 +25,7 @@ import inotifyx
 
 from .safeINotifier import SafeINotifier
 from .datasetIngestor import DatasetIngestor
+from .pathConverter import PathConverter
 from .logger import get_logger
 
 
@@ -56,6 +57,30 @@ class DatasetWatcher(threading.Thread):
 
         #: (:obj:`dict` <:obj:`str`, `any`>) ingestor configuration
         self.__config = configuration or {}
+
+        #: (:obj:`str`) core path
+        self.__corepath = meta.get("corePath", None)
+        #: (:obj:`dict` <:obj:`str`, :obj:`str`>) core notify path dict
+        self.__core_notify_path = {}
+        #: (:obj:`dict` <:obj:`str`, :obj:`str`>) notify core path dict
+        self.__notify_core_path = {}
+
+        #: (:obj:`str`) beamtime path
+        self.__bpath = os.path.split(beamtimefile)[0]
+
+        #: (:obj:`bool`) use core path
+        self.__usecorepath = False
+        if "use_corepath_as_scandir" in self.__config.keys():
+            try:
+                self.__usecorepath = bool(
+                    self.__config["use_corepath_as_scandir"])
+            except Exception as e:
+                get_logger().warning('%s' % (str(e)))
+
+        self.__conv = PathConverter(
+            self.__corepath, self._bpath,
+            self.__usecorepath and self.__corePath)
+
         #: (:obj:`str`) file with a dataset list
         self.__dsfile = dsfile
         #: (:obj:`str`) file with a ingested dataset list
@@ -97,7 +122,46 @@ class DatasetWatcher(threading.Thread):
         #: (:class:`scingestor.datasetIngestor.DatasetIngestor`)
         #: dataset ingestor
         self.__ingestor = DatasetIngestor(
-            configuration, path, dsfile, idsfile, meta, beamtimefile)
+            configuration, path, dsfile, idsfile, meta,
+            self.__conv.to_core(beamtimefile))
+
+    def __to_core(self, path):
+        """ converts notify path to core path
+
+        :param path: notify path
+        :type path: :obj:`str`
+        :returns: core path
+        :rtype: :obj:`str`
+        """
+        if not self.__usecorepath or not self.__corepath:
+            return path
+        if path in self.__notify_core_path.keys():
+            return self.__notify_core_path[path]
+        if path.startswith(self.__bpath):
+            cpath = os.self.__corepath + path[len(self.__bpath):]
+            self.__notify_core_path[path] = cpath
+            self.__core_notify_path[cpath] = path
+            return cpath
+        return path
+
+    def __from_core(self, path):
+        """ converts core path to notify path
+
+        :param path: core path
+        :type path: :obj:`str`
+        :returns: notify path
+        :rtype: :obj:`str`
+        """
+        if not self.__usecorepath or not self.__corepath:
+            return path
+        if path in self.__core_notify_path.keys():
+            return self.__core_notify_path[path]
+        if path.startswith(self.__corepath):
+            bpath = os.self.__bpath + path[len(self.__corepath):]
+            self.__core_notify_path[path] = bpath
+            self.__notify_core_path[bpath] = path
+            return bpath
+        return path
 
     def _start_notifier(self, path):
         """ start notifier
@@ -116,7 +180,7 @@ class DatasetWatcher(threading.Thread):
         """
         try:
             wqueue, watch_descriptor = self.__notifier.add_watch(
-                path,
+                self.__conv.from_core(path),
                 inotifyx.IN_ALL_EVENTS |
                 inotifyx.IN_MODIFY |
                 inotifyx.IN_OPEN |

--- a/scingestor/datasetWatcher.py
+++ b/scingestor/datasetWatcher.py
@@ -77,6 +77,7 @@ class DatasetWatcher(threading.Thread):
             except Exception as e:
                 get_logger().warning('%s' % (str(e)))
 
+        #: (:class:`scingestor.datasetWatcher.DatasetWatcher`) use core path
         self.__conv = PathConverter(
             self.__corepath, self.__bpath,
             self.__usecorepath and self.__corepath)

--- a/scingestor/datasetWatcher.py
+++ b/scingestor/datasetWatcher.py
@@ -267,6 +267,7 @@ class DatasetWatcher(threading.Thread):
                             if ffn is not None and ffn == self.__dsfile:
                                 get_logger().debug(
                                     'DatasetWatcher: Changed %s' % ffn)
+                                time.sleep(self.__delay)
                                 try:
                                     self.__ingestor.check_list()
                                 except Exception as e:
@@ -281,6 +282,7 @@ class DatasetWatcher(threading.Thread):
                                    ffn == self.__dsfile:
                                     get_logger().debug(
                                         'DatasetWatcher: Changed %s' % ffn)
+                                    time.sleep(self.__delay)
                                     try:
                                         self.__ingestor.check_list()
                                     except Exception as e:

--- a/scingestor/pathConverter.py
+++ b/scingestor/pathConverter.py
@@ -18,6 +18,8 @@
 
 # from .logger import get_logger
 
+import os
+
 
 class PathConverter:
     """ Path Converter
@@ -36,9 +38,9 @@ class PathConverter:
         self.__usecorepath = usecorepath
 
         #: (:obj:`str`) core path
-        self.__corepath = corepath
+        self.__corepath = os.path.abspath(corepath)
         #: (:obj:`str`) beamtime path
-        self.__bpath = blpath
+        self.__bpath = os.path.abspath(blpath)
 
         #: (:obj:`dict` <:obj:`str`, :obj:`str`>) core notify path dict
         self.__core_notify_path = {}

--- a/scingestor/pathConverter.py
+++ b/scingestor/pathConverter.py
@@ -1,0 +1,84 @@
+#   This file is part of scingestor - Scientific Catalog Dataset Ingestor
+#
+#    Copyright (C) 2021-2021 DESY, Jan Kotanski <jkotan@mail.desy.de>
+#
+#    nexdatas is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    nexdatas is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with scingestor.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# from .logger import get_logger
+
+
+class PathConverter:
+    """ Path Converter
+    """
+    def __init__(self, corepath, blpath, usecorepath=False):
+        """ constructor
+
+        :param corepath: core path
+        :type corepath: :obj:`str`
+        :param blpath: beamline path
+        :type blpath: :obj:`str`
+        :param usecorepath: enabled flag
+        :type usecorepath: :obj:`bool`
+        """
+        #: (:obj:`bool`) use core path
+        self.__usecorepath = usecorepath
+
+        #: (:obj:`str`) core path
+        self.__corepath = corepath
+        #: (:obj:`str`) beamtime path
+        self.__bpath = blpath
+
+        #: (:obj:`dict` <:obj:`str`, :obj:`str`>) core notify path dict
+        self.__core_notify_path = {}
+        #: (:obj:`dict` <:obj:`str`, :obj:`str`>) notify core path dict
+        self.__notify_core_path = {}
+
+    def to_core(self, path):
+        """ converts notify path to core path
+
+        :param path: notify path
+        :type path: :obj:`str`
+        :returns: core path
+        :rtype: :obj:`str`
+        """
+        if not self.__enabled:
+            return path
+        if path in self.__notify_core_path.keys():
+            return self.__notify_core_path[path]
+        if path.startswith(self.__bpath):
+            cpath = self.__corepath + path[len(self.__bpath):]
+            self.__notify_core_path[path] = cpath
+            self.__core_notify_path[cpath] = path
+            return cpath
+        return path
+
+    def from_core(self, path):
+        """ converts core path to notify path
+
+        :param path: core path
+        :type path: :obj:`str`
+        :returns: notify path
+        :rtype: :obj:`str`
+        """
+        if not self.__usecorepath or not self.__corepath:
+            return path
+        if path in self.__core_notify_path.keys():
+            return self.__core_notify_path[path]
+        if path.startswith(self.__corepath):
+            bpath = self.__bpath + path[len(self.__corepath):]
+            self.__core_notify_path[path] = bpath
+            self.__notify_core_path[bpath] = path
+            return bpath
+        return path

--- a/scingestor/pathConverter.py
+++ b/scingestor/pathConverter.py
@@ -53,7 +53,7 @@ class PathConverter:
         :returns: core path
         :rtype: :obj:`str`
         """
-        if not self.__enabled:
+        if not self.__usecorepath:
             return path
         if path in self.__notify_core_path.keys():
             return self.__notify_core_path[path]
@@ -72,7 +72,7 @@ class PathConverter:
         :returns: notify path
         :rtype: :obj:`str`
         """
-        if not self.__usecorepath or not self.__corepath:
+        if not self.__usecorepath:
             return path
         if path in self.__core_notify_path.keys():
             return self.__core_notify_path[path]

--- a/scingestor/scanDirWatcher.py
+++ b/scingestor/scanDirWatcher.py
@@ -71,6 +71,7 @@ class ScanDirWatcher(threading.Thread):
             except Exception as e:
                 get_logger().warning('%s' % (str(e)))
 
+        #: (:class:`scingestor.datasetWatcher.DatasetWatcher`) use core path
         self.__conv = PathConverter(
             self.__corepath, self.__bpath,
             self.__usecorepath and self.__corepath)

--- a/scingestor/scanDirWatcher.py
+++ b/scingestor/scanDirWatcher.py
@@ -23,6 +23,7 @@ import queue
 
 from .datasetWatcher import DatasetWatcher
 from .safeINotifier import SafeINotifier
+from .pathConverter import PathConverter
 from .logger import get_logger
 
 import inotifyx
@@ -54,29 +55,35 @@ class ScanDirWatcher(threading.Thread):
 
         #: (:obj:`dict` <:obj:`str`, `any`>) ingestor configuration
         self.__config = configuration or {}
-        #: (:obj:`str`) scan dir path
-        self.__path = path
-        #: (:obj:`str`) beamtime path and file name
-        self.__btfile = beamtimefile
+
+        #: (:obj:`str`) core path
+        self.__corepath = meta.get("corePath", None)
+
         #: (:obj:`str`) beamtime path
         self.__bpath = os.path.split(beamtimefile)[0]
+
+        #: (:obj:`bool`) use core path
+        self.__usecorepath = False
+        if "use_corepath_as_scandir" in self.__config.keys():
+            try:
+                self.__usecorepath = bool(
+                    self.__config["use_corepath_as_scandir"])
+            except Exception as e:
+                get_logger().warning('%s' % (str(e)))
+
+        self.__conv = PathConverter(
+            self.__corepath, self._bpath,
+            self.__usecorepath and self.__corePath)
+        #: (:obj:`str`) scan dir path
+        self.__path = self.__conv.to_core(path)
+        #: (:obj:`str`) beamtime core path and file name
+        self.__btfile = self.__conv.to_core(beamtimefile)
         #: (:obj:`dict` <:obj:`str`, `any`>) beamtime configuration
         self.__meta = meta
         #: (:obj:`int`) scan dir depth
         self.__depth = depth
         #: (:obj:`str`) beamtime id
         self.__beamtimeId = meta["beamtimeId"]
-        #: (:obj:`str`) beamline metadata
-        self.__meta = meta
-
-        #: (:obj:`bool`) use core path
-        self.__usecorepath = False
-        #: (:obj:`str`) core path
-        self.__corepath = meta.get("corePath", None)
-        #: (:obj:`dict` <:obj:`str`, :obj:`str`>) core notify path dict
-        self.__core_notify_path = {}
-        #: (:obj:`dict` <:obj:`str`, :obj:`str`>) notify core path dict
-        self.__notify_core_path = {}
 
         #: (:obj:`str`) scicat dataset file pattern
         self.__ds_pattern = "scicat-datasets-{beamtimeid}.lst"
@@ -106,13 +113,6 @@ class ScanDirWatcher(threading.Thread):
         self.__scandir_watchers = {}
         #: (:class:`threading.Lock`) scandir watcher dictionary lock
         self.__scandir_lock = threading.Lock()
-
-        if "use_corepath_as_scandir" in self.__config.keys():
-            try:
-                self.__usecorepath = bool(
-                    self.__config["use_corepath_as_scandir"])
-            except Exception as e:
-                get_logger().warning('%s' % (str(e)))
 
         if "get_event_timeout" in self.__config.keys():
             try:
@@ -146,44 +146,6 @@ class ScanDirWatcher(threading.Thread):
         if self.__log_dir == "/":
             self.__log_dir = ""
 
-    def __to_core(self, path):
-        """ converts notify path to core path
-
-        :param path: notify path
-        :type path: :obj:`str`
-        :returns: core path
-        :rtype: :obj:`str`
-        """
-        if not self.__usecorepath or not self.__corepath:
-            return path
-        if path in self.__notify_core_path.keys():
-            return self.__notify_core_path[path]
-        if path.startswith(self.__bpath):
-            cpath = os.self.__corepath + path[len(self.__bpath):]
-            self.__notify_core_path[path] = cpath
-            self.__core_notify_path[cpath] = path
-            return cpath
-        return path
-
-    def __from_core(self, path):
-        """ converts core path to notify path
-
-        :param path: core path
-        :type path: :obj:`str`
-        :returns: notify path
-        :rtype: :obj:`str`
-        """
-        if not self.__usecorepath or not self.__corepath:
-            return path
-        if path in self.__core_notify_path.keys():
-            return self.__core_notify_path[path]
-        if path.startswith(self.__corepath):
-            bpath = os.self.__bpath + path[len(self.__corepath):]
-            self.__core_notify_path[path] = bpath
-            self.__notify_core_path[bpath] = path
-            return bpath
-        return path
-
     def _start_notifier(self, path):
         """ start notifier
 
@@ -201,7 +163,7 @@ class ScanDirWatcher(threading.Thread):
         """
         try:
             wqueue, watch_descriptor = self.__notifier.add_watch(
-                path,
+                self.__conv.from_core(path),
                 inotifyx.IN_ALL_EVENTS |
                 inotifyx.IN_CLOSE_WRITE | inotifyx.IN_DELETE |
                 inotifyx.IN_MOVE_SELF |
@@ -243,7 +205,9 @@ class ScanDirWatcher(threading.Thread):
                                 self.__scandir_watchers[
                                     (path, self.__btfile)] = ScanDirWatcher(
                                         self.__config,
-                                        path, self.__meta, self.__btfile,
+                                        self.__conv.from_core(path),
+                                        self.__meta,
+                                        self.__conv.from_core(self.__btfile),
                                         self.__depth - 1)
                             get_logger().info(
                                 'ScanDirWatcher: Create ScanDirWatcher %s %s'
@@ -277,7 +241,9 @@ class ScanDirWatcher(threading.Thread):
                             os.makedirs(ipath, exist_ok=True)
                         dw = self.__dataset_watchers[fn] = DatasetWatcher(
                             self.__config,
-                            self.__path, fn, ifn, self.__meta, self.__btfile)
+                            self.__path,
+                            fn, ifn, self.__meta,
+                            self.__conv.from_core(self.__btfile))
                         get_logger().info(
                             'ScanDirWatcher: Creating DatasetWatcher %s' % fn)
                 if dw is not None:

--- a/scingestor/scanDirWatcher.py
+++ b/scingestor/scanDirWatcher.py
@@ -72,8 +72,8 @@ class ScanDirWatcher(threading.Thread):
                 get_logger().warning('%s' % (str(e)))
 
         self.__conv = PathConverter(
-            self.__corepath, self._bpath,
-            self.__usecorepath and self.__corePath)
+            self.__corepath, self.__bpath,
+            self.__usecorepath and self.__corepath)
         #: (:obj:`str`) scan dir path
         self.__path = self.__conv.to_core(path)
         #: (:obj:`str`) beamtime core path and file name

--- a/test/DatasetWatcherH5_test.py
+++ b/test/DatasetWatcherH5_test.py
@@ -27,6 +27,7 @@ import threading
 import shutil
 import time
 import json
+import uuid
 
 from scingestor import beamtimeWatcher
 from scingestor import safeINotifier
@@ -959,6 +960,828 @@ class DatasetWatcherH5Test(unittest.TestCase):
                 os.remove(cfgfname)
             if os.path.isdir(fdirname):
                 shutil.rmtree(fdirname)
+
+    def test_datasetfile_exist_h5_corepath(self):
+        fun = sys._getframe().f_code.co_name
+        # print("Run: %s.%s() " % (self.__class__.__name__, fun))
+        dirname = "test_current"
+        while os.path.exists(dirname):
+            dirname = dirname + '_1'
+        fdirname = os.path.abspath(dirname)
+        fsubdirname = os.path.abspath(os.path.join(dirname, "raw"))
+        fsubdirname2 = os.path.abspath(os.path.join(fsubdirname, "special"))
+        fsubdirname3 = os.path.abspath(os.path.join(fsubdirname2, "scansub"))
+        coredir = "/tmp/scingestor_core_%s" % uuid.uuid4().hex
+        cfsubdirname = os.path.abspath(os.path.join(coredir, "raw"))
+        cfsubdirname2 = os.path.abspath(os.path.join(cfsubdirname, "special"))
+        cfsubdirname3 = os.path.abspath(os.path.join(cfsubdirname2, "scansub"))
+        btmeta = "beamtime-metadata-99001284.json"
+        dslist = "scicat-datasets-99001284.lst"
+        idslist = "scicat-ingested-datasets-99001284.lst"
+        wrongdslist = "scicat-datasets-99001235.lst"
+        os.mkdir(coredir)
+        source = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                              "config",
+                              btmeta)
+        with open(source) as blf:
+            jblm = blf.read()
+            blm = json.loads(jblm)
+            blm["corePath"] = coredir
+        lsource = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                               "config",
+                               dslist)
+        wlsource = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                                "config",
+                                wrongdslist)
+        fullbtmeta = os.path.join(fdirname, btmeta)
+        # fdslist = os.path.join(fsubdirname2, dslist)
+        fidslist = os.path.join(fsubdirname2, idslist)
+        cfullbtmeta = os.path.join(coredir, btmeta)
+        cfdslist = os.path.join(cfsubdirname2, dslist)
+        cfidslist = os.path.join(cfsubdirname2, idslist)
+        credfile = os.path.join(fdirname, 'pwd')
+        url = 'http://localhost:8881'
+        logdir = "/"
+        cred = "12342345"
+        chmod = "0o662"
+        os.mkdir(fdirname)
+        os.makedirs(coredir, exist_ok=True)
+        with open(credfile, "w") as cf:
+            cf.write(cred)
+
+        wrmodule = WRITERS[self.writer]
+        filewriter.writer = wrmodule
+
+        cfg = 'beamtime_dirs:\n' \
+            '  - "{basedir}"\n' \
+            'scicat_url: "{url}"\n' \
+            'chmod_json_files: "{chmod}"\n' \
+            'use_corepath_as_scandir: true\n' \
+            'chmod_generator_switch: " -x {{chmod}} "\n' \
+            'ingestor_log_dir: "{logdir}"\n' \
+            'ingestor_credential_file: "{credfile}"\n'.format(
+                basedir=fdirname, url=url, logdir=logdir,
+                credfile=credfile, chmod=chmod)
+
+        cfgfname = "%s_%s.yaml" % (self.__class__.__name__, fun)
+        with open(cfgfname, "w+") as cf:
+            cf.write(cfg)
+        commands = [('scicat_dataset_ingestor -c %s -r10 --log debug'
+                     % cfgfname).split(),
+                    ('scicat_dataset_ingestor --config %s -r10 -l debug'
+                     % cfgfname).split()]
+        # commands.pop()
+
+        args = [
+            [
+                "myscan_00001.nxs",
+                "Test experiment",
+                "BL1234554",
+                "PETRA III",
+                "P3",
+                "2014-02-12T15:19:21+00:00",
+                "2014-02-15T15:17:21+00:00",
+                "water",
+                "H20",
+                'technique: "saxs"',
+            ],
+            [
+                "myscan_00002.nxs",
+                "My experiment",
+                "BT123_ADSAD",
+                "Petra III",
+                "PIII",
+                "2019-02-14T15:19:21+00:00",
+                "2019-02-15T15:27:21+00:00",
+                "test sample",
+                "LaB6",
+                'techniques_pids:\n'
+                '  - "PaNET01191"\n'
+                '  - "PaNET01188"\n'
+                '  - "PaNET01098"\n'
+            ],
+        ]
+        ltechs = [
+            [
+                {
+                    'name': 'small angle x-ray scattering',
+                    'pid':
+                    'http://purl.org/pan-science/PaNET/PaNET01188'
+                }
+            ],
+            [
+                {
+                    'name': 'wide angle x-ray scattering',
+                    'pid':
+                    'http://purl.org/pan-science/PaNET/PaNET01191'
+                },
+                {
+                    'name': 'small angle x-ray scattering',
+                    'pid':
+                    'http://purl.org/pan-science/PaNET/PaNET01188'
+                },
+                {
+                    'name': 'grazing incidence diffraction',
+                    'pid':
+                    'http://purl.org/pan-science/PaNET/PaNET01098'
+                },
+            ],
+
+        ]
+
+        try:
+            for cmd in commands:
+                time.sleep(1)
+                os.mkdir(fsubdirname)
+                os.mkdir(fsubdirname2)
+                os.mkdir(fsubdirname3)
+                os.mkdir(cfsubdirname)
+                os.mkdir(cfsubdirname2)
+                os.mkdir(cfsubdirname3)
+
+                for k, arg in enumerate(args):
+                    nxsfilename = os.path.join(fsubdirname2, arg[0])
+                    cnxsfilename = os.path.join(cfsubdirname2, arg[0])
+                    # dsfilename = nxsfilename[:-4] + ".scan.json"
+                    cdbfilename = cnxsfilename[:-4] + ".origdatablock.json"
+                    title = arg[1]
+                    beamtime = arg[2]
+                    insname = arg[3]
+                    inssname = arg[4]
+                    stime = arg[5]
+                    etime = arg[6]
+                    smpl = arg[7]
+                    formula = arg[8]
+
+                    nxsfile = filewriter.create_file(
+                        nxsfilename, overwrite=True)
+                    rt = nxsfile.root()
+                    entry = rt.create_group("entry12345", "NXentry")
+                    ins = entry.create_group("instrument", "NXinstrument")
+                    det = ins.create_group("detector", "NXdetector")
+                    entry.create_field(
+                        "experiment_description", "string").write(arg[9])
+                    entry.create_group("data", "NXdata")
+                    sample = entry.create_group("sample", "NXsample")
+                    det.create_field("intimage", "uint32", [0, 30], [1, 30])
+
+                    entry.create_field("title", "string").write(title)
+                    entry.create_field(
+                        "experiment_identifier", "string").write(beamtime)
+                    entry.create_field("start_time", "string").write(stime)
+                    entry.create_field("end_time", "string").write(etime)
+                    sname = ins.create_field("name", "string")
+                    sname.write(insname)
+                    sattr = sname.attributes.create("short_name", "string")
+                    sattr.write(inssname)
+                    sname = sample.create_field("name", "string")
+                    sname.write(smpl)
+                    sfml = sample.create_field("chemical_formula", "string")
+                    sfml.write(formula)
+                    nxsfile.close()
+
+                    shutil.copy(nxsfilename, cfsubdirname2)
+                #  shutil.copy(source, fdirname)
+                with open(cfullbtmeta, "w") as blf:
+                    blf.write(json.dumps(blm))
+                with open(fullbtmeta, "w") as blf:
+                    blf.write(json.dumps(blm))
+                shutil.copy(lsource, fsubdirname2)
+                shutil.copy(wlsource, fsubdirname)
+                shutil.copy(lsource, cfsubdirname2)
+                shutil.copy(wlsource, cfsubdirname)
+                self.notifier = safeINotifier.SafeINotifier()
+                cnt = self.notifier.id_queue_counter + 1
+                self.__server.reset()
+                if os.path.exists(fidslist):
+                    os.remove(fidslist)
+                vl, er = self.runtest(cmd)
+                ser = er.split("\n")
+                seri = [ln for ln in ser if not ln.startswith("127.0.0.1")]
+                dseri = [ln for ln in seri if "DEBUG :" not in ln]
+
+                for k, arg in enumerate(args):
+                    nxsfilename = os.path.join(fsubdirname2, arg[0])
+                    cnxsfilename = os.path.join(cfsubdirname2, arg[0])
+                    cdsfilename = cnxsfilename[:-4] + ".scan.json"
+                    cdbfilename = cnxsfilename[:-4] + ".origdatablock.json"
+                    status = os.stat(cdsfilename)
+                    self.assertEqual(chmod, str(oct(status.st_mode & 0o777)))
+                    status = os.stat(cdbfilename)
+                    self.assertEqual(chmod, str(oct(status.st_mode & 0o777)))
+
+                # print(vl)
+                # print(er)
+
+                # nodebug = "\n".join([ee for ee in er.split("\n")
+                #                      if (("DEBUG :" not in ee) and
+                #                          (not ee.startswith("127.0.0.1")))])
+                # sero = [ln for ln in ser if ln.startswith("127.0.0.1")]
+                try:
+                    self.assertEqual(
+                        'INFO : BeamtimeWatcher: Adding watch {cnt1}: '
+                        '{basedir}\n'
+                        'INFO : BeamtimeWatcher: Create ScanDirWatcher '
+                        '{basedir} {btmeta}\n'
+                        'INFO : ScanDirWatcher: Adding watch {cnt2}: '
+                        '{cbasedir}\n'
+                        'INFO : ScanDirWatcher: Create ScanDirWatcher '
+                        '{subdir} {cbtmeta}\n'
+                        'INFO : ScanDirWatcher: Adding watch {cnt3}: '
+                        '{subdir}\n'
+                        'INFO : ScanDirWatcher: Create ScanDirWatcher '
+                        '{subdir2} {cbtmeta}\n'
+                        'INFO : ScanDirWatcher: Adding watch {cnt4}: '
+                        '{subdir2}\n'
+                        'INFO : ScanDirWatcher: Creating DatasetWatcher '
+                        '{dslist}\n'
+                        'INFO : DatasetWatcher: Adding watch {cnt5}: '
+                        '{dslist} {idslist}\n'
+                        'INFO : DatasetWatcher: Waiting datasets: '
+                        '[\'{sc1}\', \'{sc2}\']\n'
+                        'INFO : DatasetWatcher: Ingested datasets: []\n'
+                        'INFO : DatasetIngestor: Ingesting: {dslist} {sc1}\n'
+                        'INFO : DatasetIngestor: Generating nxs metadata: '
+                        '{sc1} {subdir2}/{sc1}.scan.json\n'
+                        'INFO : DatasetIngestor: '
+                        'Generating origdatablock metadata:'
+                        ' {sc1} {subdir2}/{sc1}.origdatablock.json\n'
+                        'INFO : DatasetIngestor: Check if dataset exists: '
+                        '10.3204/99001284/{sc1}\n'
+                        'INFO : DatasetIngestor: Post the dataset: '
+                        '10.3204/99001284/{sc1}\n'
+                        'INFO : DatasetIngestor: Ingesting: {dslist} {sc2}\n'
+                        'INFO : DatasetIngestor: Generating nxs metadata: '
+                        '{sc2} {subdir2}/{sc2}.scan.json\n'
+                        'INFO : DatasetIngestor: '
+                        'Generating origdatablock metadata:'
+                        ' {sc2} {subdir2}/{sc2}.origdatablock.json\n'
+                        'INFO : DatasetIngestor: Check if dataset exists: '
+                        '10.3204/99001284/{sc2}\n'
+                        'INFO : DatasetIngestor: Post the dataset: '
+                        '10.3204/99001284/{sc2}\n'
+                        'INFO : BeamtimeWatcher: Removing watch {cnt1}: '
+                        '{basedir}\n'
+                        'INFO : BeamtimeWatcher: '
+                        'Stopping ScanDirWatcher {btmeta}\n'
+                        'INFO : ScanDirWatcher: Removing watch {cnt2}: '
+                        '{cbasedir}\n'
+                        'INFO : ScanDirWatcher: Stopping ScanDirWatcher '
+                        '{cbtmeta}\n'
+                        'INFO : ScanDirWatcher: Removing watch {cnt3}: '
+                        '{subdir}\n'
+                        'INFO : ScanDirWatcher: Stopping ScanDirWatcher '
+                        '{cbtmeta}\n'
+                        'INFO : ScanDirWatcher: Removing watch {cnt4}: '
+                        '{subdir2}\n'
+                        'INFO : ScanDirWatcher: Stopping DatasetWatcher '
+                        '{dslist}\n'
+                        'INFO : ScanDirWatcher: Removing watch {cnt5}: '
+                        '{dslist}\n'
+                        .format(basedir=fdirname, cbasedir=coredir,
+                                btmeta=fullbtmeta,
+                                cbtmeta=cfullbtmeta,
+                                subdir=cfsubdirname, subdir2=cfsubdirname2,
+                                dslist=cfdslist, idslist=cfidslist,
+                                cnt1=cnt, cnt2=(cnt + 1), cnt3=(cnt + 2),
+                                cnt4=(cnt + 3), cnt5=(cnt + 4),
+                                sc1='myscan_00001', sc2='myscan_00002'),
+                        '\n'.join(dseri))
+                except Exception:
+                    print(er)
+                    raise
+                self.assertEqual(
+                    "Login: ingestor\n"
+                    "RawDatasets: 99001284/myscan_00001\n"
+                    "OrigDatablocks: 10.3204/99001284/myscan_00001\n"
+                    "RawDatasets: 99001284/myscan_00002\n"
+                    "OrigDatablocks: 10.3204/99001284/myscan_00002\n", vl)
+                self.assertEqual(len(self.__server.userslogin), 1)
+                self.assertEqual(
+                    self.__server.userslogin[0],
+                    b'{"username": "ingestor", "password": "12342345"}')
+                self.assertEqual(len(self.__server.datasets), 2)
+                self.myAssertDict(
+                    json.loads(self.__server.datasets[0]),
+                    {'contactEmail': 'BSName',
+                     'creationTime': args[0][6],
+                     'createdAt': '2022-05-14 11:54:29',
+                     'creationLocation': '/DESY/PETRA III/p00',
+                     'description': args[0][1],
+                     'endTime': args[0][6],
+                     'isPublished': False,
+                     'techniques': ltechs[0],
+                     'owner': 'Ouruser',
+                     'ownerGroup': '99001284-part',
+                     'ownerEmail': 'appuser@fake.com',
+                     'pid': '99001284/myscan_00001',
+                     'accessGroups': [
+                         '99001284-clbt', '99001284-dmgt', 'p00dmgt'],
+                     'datasetName': 'myscan_00001',
+                     'principalInvestigator': 'appuser@fake.com',
+                     'proposalId': '99001284',
+                     'scientificMetadata':
+                     {'NX_class': 'NXentry',
+                      'name': 'entry12345',
+                      'experiment_description': {
+                        'value': args[0][9]
+                      },
+                      'data': {'NX_class': 'NXdata'},
+                      'end_time': {'value': '%s' % args[0][6]},
+                      'experiment_identifier': {'value': '%s' % args[0][2]},
+                      'instrument': {
+                          'NX_class': 'NXinstrument',
+                          'detector': {
+                              'NX_class': 'NXdetector',
+                              'intimage': {
+                                  'shape': [0, 30]}},
+                          'name': {
+                            'short_name': '%s' % args[0][4],
+                            'value': '%s' % args[0][3]}},
+                      'sample': {
+                        'NX_class': 'NXsample',
+                          'chemical_formula': {'value': '%s' % args[0][8]},
+                          'name': {'value': '%s' % args[0][7]}},
+                      'start_time': {
+                          'value': '%s' % args[0][5]},
+                      'title': {'value': '%s' % args[0][1]},
+                      'DOOR_proposalId': '99991173',
+                      'beamtimeId': '99001284'},
+                     'sourceFolder':
+                     '%s/raw/special' % coredir,
+                     'type': 'raw',
+                     'updatedAt': '2022-05-14 11:54:29'})
+                self.myAssertDict(
+                    json.loads(self.__server.datasets[1]),
+                    {'contactEmail': 'BSName',
+                     'creationTime': args[1][6],
+                     'createdAt': '2022-05-14 11:54:29',
+                     'creationLocation': '/DESY/PETRA III/p00',
+                     'description': args[1][1],
+                     'endTime': args[1][6],
+                     'isPublished': False,
+                     'techniques': ltechs[1],
+                     'owner': 'Ouruser',
+                     'ownerGroup': '99001284-part',
+                     'ownerEmail': 'appuser@fake.com',
+                     'pid': '99001284/myscan_00002',
+                     'accessGroups': [
+                         '99001284-clbt', '99001284-dmgt', 'p00dmgt'],
+                     'datasetName': 'myscan_00002',
+                     'principalInvestigator': 'appuser@fake.com',
+                     'proposalId': '99001284',
+                     'scientificMetadata':
+                     {'NX_class': 'NXentry',
+                      'name': 'entry12345',
+                      'experiment_description': {
+                        'value':  args[1][9]
+                      },
+                      'data': {'NX_class': 'NXdata'},
+                      'end_time': {'value': '%s' % args[1][6]},
+                      'experiment_identifier': {'value': '%s' % args[1][2]},
+                      'instrument': {
+                          'NX_class': 'NXinstrument',
+                          'detector': {
+                              'NX_class': 'NXdetector',
+                              'intimage': {
+                                  'shape': [0, 30]}},
+                          'name': {
+                              'short_name': '%s' % args[1][4],
+                              'value': '%s' % args[1][3]}},
+                      'sample': {
+                        'NX_class': 'NXsample',
+                          'chemical_formula': {'value': '%s' % args[1][8]},
+                          'name': {'value': '%s' % args[1][7]}},
+                      'start_time': {
+                          'value': '%s' % args[1][5]},
+                      'title': {'value': '%s' % args[1][1]},
+                      'DOOR_proposalId': '99991173',
+                      'beamtimeId': '99001284'},
+                     'sourceFolder':
+                     '%s/raw/special' % coredir,
+                     'type': 'raw',
+                     'updatedAt': '2022-05-14 11:54:29'})
+                self.assertEqual(len(self.__server.origdatablocks), 2)
+                self.myAssertDict(
+                    json.loads(self.__server.origdatablocks[0]),
+                    {'dataFileList': [
+                        {'gid': 'jkotan',
+                         'path': 'myscan_00001.scan.json',
+                         'perm': '-rw-r--r--',
+                         'size': 629,
+                         'time': '2022-07-05T19:07:16.683673+0200',
+                         'uid': 'jkotan'}],
+                     'ownerGroup': '99001284-part',
+                     'datasetId': '10.3204/99001284/myscan_00001',
+                     'accessGroups': [
+                         '99001284-clbt', '99001284-dmgt', 'p00dmgt'],
+                     'size': 629}, skip=["dataFileList", "size"])
+                self.myAssertDict(
+                    json.loads(self.__server.origdatablocks[1]),
+                    {'dataFileList': [
+                        {'gid': 'jkotan',
+                         'path': 'myscan_00001.scan.json',
+                         'perm': '-rw-r--r--',
+                         'size': 629,
+                         'time': '2022-07-05T19:07:16.683673+0200',
+                         'uid': 'jkotan'}],
+                     'ownerGroup': '99001284-part',
+                     'datasetId': '10.3204/99001284/myscan_00002',
+                     'accessGroups': [
+                         '99001284-clbt', '99001284-dmgt', 'p00dmgt'],
+                     'size': 629}, skip=["dataFileList", "size"])
+                if os.path.isdir(fsubdirname):
+                    shutil.rmtree(fsubdirname)
+                if os.path.isdir(cfsubdirname):
+                    shutil.rmtree(cfsubdirname)
+        finally:
+            if os.path.exists(cfgfname):
+                os.remove(cfgfname)
+            if os.path.isdir(fdirname):
+                shutil.rmtree(fdirname)
+            if os.path.isdir(coredir):
+                shutil.rmtree(coredir)
+
+    def test_datasetfile_add_h5_corepath(self):
+        fun = sys._getframe().f_code.co_name
+        # print("Run: %s.%s() " % (self.__class__.__name__, fun))
+        dirname = "test_current"
+        while os.path.exists(dirname):
+            dirname = dirname + '_1'
+        fdirname = os.path.abspath(dirname)
+        coredir = "/tmp/scingestor_core_%s" % uuid.uuid4().hex
+        fsubdirname = os.path.abspath(os.path.join(dirname, "raw"))
+        fsubdirname2 = os.path.abspath(os.path.join(fsubdirname, "special"))
+        fsubdirname3 = os.path.abspath(os.path.join(fsubdirname2, "scansub"))
+        cfsubdirname = os.path.abspath(os.path.join(coredir, "raw"))
+        cfsubdirname2 = os.path.abspath(os.path.join(cfsubdirname, "special"))
+        cfsubdirname3 = os.path.abspath(os.path.join(cfsubdirname2, "scansub"))
+        os.mkdir(fdirname)
+        os.makedirs(coredir, exist_ok=True)
+        btmeta = "beamtime-metadata-99001284.json"
+        dslist = "scicat-datasets-99001284.lst"
+        idslist = "scicat-ingested-datasets-99001284.lst"
+        # wrongdslist = "scicat-datasets-99001235.lst"
+        source = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                              "config",
+                              btmeta)
+        cfullbtmeta = os.path.join(coredir, btmeta)
+        fullbtmeta = os.path.join(dirname, btmeta)
+        with open(source) as blf:
+            jblm = blf.read()
+            blm = json.loads(jblm)
+            blm["corePath"] = coredir
+        lsource = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                               "config",
+                               dslist)
+        # shutil.copy(source, fdirname)
+        with open(cfullbtmeta, "w") as blf:
+            blf.write(json.dumps(blm))
+        with open(fullbtmeta, "w") as blf:
+            blf.write(json.dumps(blm))
+        # shutil.copy(lsource, fsubdirname2)
+        # shutil.copy(wlsource, fsubdirname)
+        fullbtmeta = os.path.join(fdirname, btmeta)
+        fdslist = os.path.join(fsubdirname2, dslist)
+        fidslist = os.path.join(fsubdirname2, idslist)
+        cfullbtmeta = os.path.join(coredir, btmeta)
+        cfdslist = os.path.join(cfsubdirname2, dslist)
+        cfidslist = os.path.join(cfsubdirname2, idslist)
+        credfile = os.path.join(fdirname, 'pwd')
+        url = 'http://localhost:8881'
+        logdir = "/"
+        cred = "12342345"
+        username = "myingestor"
+        with open(credfile, "w") as cf:
+            cf.write(cred)
+
+        cfg = 'beamtime_dirs:\n' \
+            '  - "{basedir}"\n' \
+            'scicat_url: "{url}"\n' \
+            'oned_in_metadata: true\n' \
+            'use_corepath_as_scandir: true\n' \
+            'oned_dataset_generator_switch: " --oned "\n' \
+            'ingestor_log_dir: "{logdir}"\n' \
+            'ingestor_username: "{username}"\n' \
+            'ingestor_credential_file: "{credfile}"\n'.format(
+                basedir=fdirname, url=url, logdir=logdir,
+                username=username, credfile=credfile)
+
+        cfgfname = "%s_%s.yaml" % (self.__class__.__name__, fun)
+        with open(cfgfname, "w+") as cf:
+            cf.write(cfg)
+
+        wrmodule = WRITERS[self.writer]
+        filewriter.writer = wrmodule
+
+        commands = [('scicat_dataset_ingestor -c %s -r36 --log debug'
+                     % cfgfname).split(),
+                    ('scicat_dataset_ingestor --config %s -r36 -l debug'
+                     % cfgfname).split()]
+
+        arg = [
+            "myscan_%05i.nxs",
+            "Test experiment",
+            "BL1234554",
+            "PETRA III",
+            "P3",
+            "2014-02-12T15:19:21+00:00",
+            "2014-02-15T15:17:21+00:00",
+            "water",
+            "H20",
+            'technique: "saxs"',
+        ]
+        ltech = [
+            {
+                'name': 'small angle x-ray scattering',
+                'pid':
+                'http://purl.org/pan-science/PaNET/PaNET01188'
+            }
+        ]
+
+        def test_thread():
+            """ test thread which adds and removes beamtime metadata file """
+            time.sleep(3)
+            shutil.copy(lsource, fsubdirname2)
+            shutil.copy(lsource, cfsubdirname2)
+            time.sleep(5)
+            os.mkdir(fsubdirname3)
+            os.mkdir(cfsubdirname3)
+            time.sleep(12)
+            with open(fdslist, "a+") as fds:
+                fds.write("myscan_00003\n")
+                fds.write("myscan_00004\n")
+            shutil.copy(fdslist, cfsubdirname2)
+
+        # commands.pop()
+        try:
+            for cmd in commands:
+                os.mkdir(fsubdirname)
+                os.mkdir(fsubdirname2)
+                os.mkdir(cfsubdirname)
+                os.mkdir(cfsubdirname2)
+
+                for k in range(4):
+                    nxsfilename = os.path.join(
+                        fsubdirname2, arg[0] % (k + 1))
+                    title = arg[1]
+                    beamtime = arg[2]
+                    insname = arg[3]
+                    inssname = arg[4]
+                    stime = arg[5]
+                    etime = arg[6]
+                    smpl = arg[7]
+                    formula = arg[8]
+                    spectrum = [243, 34, 34, 23, 334, 34, 34, 33, 32, 11]
+
+                    nxsfile = filewriter.create_file(
+                        nxsfilename, overwrite=True)
+                    rt = nxsfile.root()
+                    entry = rt.create_group("entry12345", "NXentry")
+                    ins = entry.create_group("instrument", "NXinstrument")
+                    det = ins.create_group("detector", "NXdetector")
+                    entry.create_field(
+                        "experiment_description", "string").write(arg[9])
+                    entry.create_group("data", "NXdata")
+                    sample = entry.create_group("sample", "NXsample")
+                    det.create_field("intimage", "uint32", [0, 30], [1, 30])
+                    sp = det.create_field("spectrum", "uint32", [10], [10])
+                    sp.write(spectrum)
+
+                    entry.create_field("title", "string").write(title)
+                    entry.create_field(
+                        "experiment_identifier", "string").write(beamtime)
+                    entry.create_field("start_time", "string").write(stime)
+                    entry.create_field("end_time", "string").write(etime)
+                    sname = ins.create_field("name", "string")
+                    sname.write(insname)
+                    sattr = sname.attributes.create("short_name", "string")
+                    sattr.write(inssname)
+                    sname = sample.create_field("name", "string")
+                    sname.write(smpl)
+                    sfml = sample.create_field("chemical_formula", "string")
+                    sfml.write(formula)
+                    nxsfile.close()
+                    shutil.copy(nxsfilename, cfsubdirname2)
+
+                # print(cmd)
+                self.notifier = safeINotifier.SafeINotifier()
+                cnt = self.notifier.id_queue_counter + 1
+                self.__server.reset()
+                shutil.copy(lsource, fsubdirname2)
+                shutil.copy(lsource, cfsubdirname2)
+                if os.path.exists(fidslist):
+                    os.remove(fidslist)
+                th = threading.Thread(target=test_thread)
+                th.start()
+                vl, er = self.runtest(cmd)
+                th.join()
+                ser = er.split("\n")
+                seri = [ln for ln in ser if not ln.startswith("127.0.0.1")]
+                dseri = [ln for ln in seri if "DEBUG :" not in ln]
+                # sero = [ln for ln in ser if ln.startswith("127.0.0.1")]
+                # print(er)
+                try:
+                    self.assertEqual(
+                        'INFO : BeamtimeWatcher: Adding watch {cnt1}: '
+                        '{basedir}\n'
+                        'INFO : BeamtimeWatcher: Create ScanDirWatcher '
+                        '{basedir} {btmeta}\n'
+                        'INFO : ScanDirWatcher: Adding watch {cnt2}: '
+                        '{cbasedir}\n'
+                        'INFO : ScanDirWatcher: Create ScanDirWatcher '
+                        '{subdir} {cbtmeta}\n'
+                        'INFO : ScanDirWatcher: Adding watch {cnt3}: '
+                        '{subdir}\n'
+                        'INFO : ScanDirWatcher: Create ScanDirWatcher '
+                        '{subdir2} {cbtmeta}\n'
+                        'INFO : ScanDirWatcher: Adding watch {cnt4}: '
+                        '{subdir2}\n'
+                        'INFO : ScanDirWatcher: Creating DatasetWatcher '
+                        '{dslist}\n'
+                        'INFO : DatasetWatcher: Adding watch {cnt5}: '
+                        '{dslist} {idslist}\n'
+                        'INFO : DatasetWatcher: Waiting datasets: '
+                        '[\'{sc1}\', \'{sc2}\']\n'
+                        'INFO : DatasetWatcher: Ingested datasets: []\n'
+                        'INFO : DatasetIngestor: Ingesting: {dslist} {sc1}\n'
+                        'INFO : DatasetIngestor: Generating nxs metadata: '
+                        '{sc1} {subdir2}/{sc1}.scan.json\n'
+                        'INFO : DatasetIngestor: '
+                        'Generating origdatablock metadata:'
+                        ' {sc1} {subdir2}/{sc1}.origdatablock.json\n'
+                        'INFO : DatasetIngestor: Check if dataset exists: '
+                        '10.3204/99001284/{sc1}\n'
+                        'INFO : DatasetIngestor: Post the dataset: '
+                        '10.3204/99001284/{sc1}\n'
+                        'INFO : DatasetIngestor: Ingesting: {dslist} {sc2}\n'
+                        'INFO : DatasetIngestor: Generating nxs metadata: '
+                        '{sc2} {subdir2}/{sc2}.scan.json\n'
+                        'INFO : DatasetIngestor: '
+                        'Generating origdatablock metadata:'
+                        ' {sc2} {subdir2}/{sc2}.origdatablock.json\n'
+                        'INFO : DatasetIngestor: Check if dataset exists: '
+                        '10.3204/99001284/{sc2}\n'
+                        'INFO : DatasetIngestor: Post the dataset: '
+                        '10.3204/99001284/{sc2}\n'
+                        'INFO : DatasetIngestor: Ingesting: {dslist} {sc3}\n'
+                        'INFO : DatasetIngestor: Generating nxs metadata: '
+                        '{sc3} {subdir2}/{sc3}.scan.json\n'
+                        'INFO : DatasetIngestor: '
+                        'Generating origdatablock metadata:'
+                        ' {sc3} {subdir2}/{sc3}.origdatablock.json\n'
+                        'INFO : DatasetIngestor: Check if dataset exists: '
+                        '10.3204/99001284/{sc3}\n'
+                        'INFO : DatasetIngestor: Post the dataset: '
+                        '10.3204/99001284/{sc3}\n'
+                        'INFO : DatasetIngestor: Ingesting: {dslist} {sc4}\n'
+                        'INFO : DatasetIngestor: Generating nxs metadata: '
+                        '{sc4} {subdir2}/{sc4}.scan.json\n'
+                        'INFO : DatasetIngestor: '
+                        'Generating origdatablock metadata:'
+                        ' {sc4} {subdir2}/{sc4}.origdatablock.json\n'
+                        'INFO : DatasetIngestor: Check if dataset exists: '
+                        '10.3204/99001284/{sc4}\n'
+                        'INFO : DatasetIngestor: Post the dataset: '
+                        '10.3204/99001284/{sc4}\n'
+                        'INFO : BeamtimeWatcher: Removing watch {cnt1}: '
+                        '{basedir}\n'
+                        'INFO : BeamtimeWatcher: '
+                        'Stopping ScanDirWatcher {btmeta}\n'
+                        'INFO : ScanDirWatcher: Removing watch {cnt2}: '
+                        '{cbasedir}\n'
+                        'INFO : ScanDirWatcher: Stopping ScanDirWatcher '
+                        '{cbtmeta}\n'
+                        'INFO : ScanDirWatcher: Removing watch {cnt3}: '
+                        '{subdir}\n'
+                        'INFO : ScanDirWatcher: Stopping ScanDirWatcher '
+                        '{cbtmeta}\n'
+                        'INFO : ScanDirWatcher: Removing watch {cnt4}: '
+                        '{subdir2}\n'
+                        'INFO : ScanDirWatcher: Stopping DatasetWatcher '
+                        '{dslist}\n'
+                        'INFO : ScanDirWatcher: Removing watch {cnt5}: '
+                        '{dslist}\n'
+                        .format(
+                            basedir=fdirname, cbasedir=coredir,
+                            btmeta=fullbtmeta,
+                            cbtmeta=cfullbtmeta,
+                            subdir=cfsubdirname, subdir2=cfsubdirname2,
+                            dslist=cfdslist, idslist=cfidslist,
+                            cnt1=cnt, cnt2=(cnt + 1), cnt3=(cnt + 2),
+                            cnt4=(cnt + 3), cnt5=(cnt + 4),
+                            sc1='myscan_00001', sc2='myscan_00002',
+                            sc3='myscan_00003', sc4='myscan_00004'),
+                        "\n".join(dseri))
+                except Exception:
+                    print(er)
+                    raise
+                self.assertEqual(
+                    'Login: myingestor\n'
+                    "RawDatasets: 99001284/myscan_00001\n"
+                    "OrigDatablocks: 10.3204/99001284/myscan_00001\n"
+                    "RawDatasets: 99001284/myscan_00002\n"
+                    "OrigDatablocks: 10.3204/99001284/myscan_00002\n"
+                    'Login: myingestor\n'
+                    "RawDatasets: 99001284/myscan_00003\n"
+                    "OrigDatablocks: 10.3204/99001284/myscan_00003\n"
+                    "RawDatasets: 99001284/myscan_00004\n"
+                    "OrigDatablocks: 10.3204/99001284/myscan_00004\n", vl)
+                self.assertEqual(len(self.__server.userslogin), 2)
+                self.assertEqual(
+                    self.__server.userslogin[0],
+                    b'{"username": "myingestor", "password": "12342345"}')
+                self.assertEqual(
+                    self.__server.userslogin[1],
+                    b'{"username": "myingestor", "password": "12342345"}')
+                self.assertEqual(len(self.__server.datasets), 4)
+                for i in range(4):
+                    self.myAssertDict(
+                        json.loads(self.__server.datasets[i]),
+                        {'contactEmail': 'BSName',
+                         'creationTime': arg[6],
+                         'createdAt': '2022-05-14 11:54:29',
+                         'creationLocation': '/DESY/PETRA III/p00',
+                         'description': arg[1],
+                         'endTime': arg[6],
+                         'isPublished': False,
+                         'techniques': ltech,
+                         'owner': 'Ouruser',
+                         'ownerEmail': 'appuser@fake.com',
+                         'pid': '99001284/myscan_%05i' % (i + 1),
+                         'datasetName': 'myscan_%05i' % (i + 1),
+                         'accessGroups': [
+                             '99001284-clbt', '99001284-dmgt', 'p00dmgt'],
+                         'principalInvestigator': 'appuser@fake.com',
+                         'ownerGroup': '99001284-part',
+                         'proposalId': '99001284',
+                         'scientificMetadata':
+                         {'NX_class': 'NXentry',
+                          'name': 'entry12345',
+                          'experiment_description': {
+                              'value': arg[9]
+                          },
+                          'data': {'NX_class': 'NXdata'},
+                          'end_time': {'value': '%s' % arg[6]},
+                          'experiment_identifier': {'value': '%s' % arg[2]},
+                          'instrument': {
+                              'NX_class': 'NXinstrument',
+                              'detector': {
+                                  'NX_class': 'NXdetector',
+                                  'intimage': {
+                                      'shape': [0, 30]
+                                  },
+                                  'spectrum': {
+                                      'value': spectrum,
+                                      'shape': [10]
+                                  }
+                              },
+
+                              'name': {
+                                  'short_name': '%s' % arg[4],
+                                  'value': '%s' % arg[3]}},
+                          'sample': {
+                              'NX_class': 'NXsample',
+                              'chemical_formula': {'value': '%s' % arg[8]},
+                              'name': {'value': '%s' % arg[7]}},
+                          'start_time': {
+                              'value': '%s' % arg[5]},
+                          'title': {'value': '%s' % arg[1]},
+                          'DOOR_proposalId': '99991173',
+                          'beamtimeId': '99001284'},
+                         'sourceFolder':
+                         '%s/raw/special' % coredir,
+                         'type': 'raw',
+                         'updatedAt': '2022-05-14 11:54:29'})
+
+                self.assertEqual(len(self.__server.origdatablocks), 4)
+                for i in range(4):
+                    self.myAssertDict(
+                        json.loads(self.__server.origdatablocks[i]),
+                        {'dataFileList': [
+                            {'gid': 'jkotan',
+                             'path': 'myscan_00001.scan.json',
+                             'perm': '-rw-r--r--',
+                             'size': 629,
+                             'time': '2022-07-05T19:07:16.683673+0200',
+                             'uid': 'jkotan'}],
+                         'ownerGroup': '99001284-part',
+                         'datasetId':
+                         '10.3204/99001284/myscan_%05i' % (i + 1),
+                         'accessGroups': [
+                             '99001284-clbt', '99001284-dmgt', 'p00dmgt'],
+                         'size': 629}, skip=["dataFileList", "size"])
+                if os.path.isdir(fsubdirname):
+                    shutil.rmtree(fsubdirname)
+                if os.path.isdir(cfsubdirname):
+                    shutil.rmtree(cfsubdirname)
+        finally:
+            if os.path.exists(cfgfname):
+                os.remove(cfgfname)
+            if os.path.isdir(fdirname):
+                shutil.rmtree(fdirname)
+            if os.path.isdir(coredir):
+                shutil.rmtree(coredir)
 
     def test_datasetfile_exist_h5_script(self):
         fun = sys._getframe().f_code.co_name

--- a/test/config/beamtime-metadata-99001284.json
+++ b/test/config/beamtime-metadata-99001284.json
@@ -1,0 +1,47 @@
+{
+    "applicant": {
+        "email": "appuser@fake.com",
+        "institute": "Academy of Sciences",
+        "lastname": "Ouruser",
+        "userId": "990123",
+        "username": "John_Ouruser"
+    },
+    "beamline": "p00",
+    "beamlineAlias": "P00",
+    "beamlineSetup": "Microprobe",
+    "beamtimeId": "99001284",
+    "contact": "BSName",
+    "corePath": "/tmp/scingestor_core_/9901284",
+    "eventEnd": "2022-05-19 09:00:00",
+    "eventStart": "2022-05-14 09:00:00",
+    "facility": "PETRA III",
+    "generated": "2022-05-14 11:54:29",
+    "leader": {
+        "email": "peter.smithson@fake.de",
+        "institute": "Academy of Sciences",
+        "lastname": "Smithson",
+        "userId": "9987",
+        "username": "psmithson"
+    },
+    "pi": {
+        "email": "appuser@fake.com",
+        "institute": "Academy of Sciences",
+        "lastname": "Ouruser",
+        "userId": "990123",
+        "username": "John_Ouruser"
+    },
+    "proposalId": "99991173",
+    "proposalType": "I",
+    "title": "H20 distribution",
+    "unixId": "None",
+    "users": {
+        "doorDb": [
+            "asdgf",
+            "asaaa",
+            "asdsd",
+            "jarre"
+        ],
+        "special": [],
+        "unknown": []
+    }
+}

--- a/test/config/scicat-datasets-99001284.lst
+++ b/test/config/scicat-datasets-99001284.lst
@@ -1,0 +1,2 @@
+myscan_00001
+myscan_00002


### PR DESCRIPTION
It resolves #116 by adding support for the `use_corepath_as_scandir` configuration variable