### PR TITLE
Issue 172: allow to use {homepath} in metadata_copy_map_file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@
 	* improve tests (#163)
 	* add support for .nx, .h5, .ndf NeXus extensions (#165)
 	* add master_file_extension_list to the file configuration (#168)
+	* allow to use {homepath} in metadata_copy_map_file (#172)
 	* tagged as 0.4.0
 
 2021-12-08 Jan Kotanski <jan.kotanski@desy.de>

--- a/scingestor/datasetIngestor.py
+++ b/scingestor/datasetIngestor.py
@@ -299,7 +299,9 @@ class DatasetIngestor:
         if "hidden_attributes" in self.__config.keys():
             self.__hiddenattributes = self.__config["hidden_attributes"]
         if "metadata_copy_map_file" in self.__config.keys():
-            self.__copymapfile = self.__config["metadata_copy_map_file"]
+            self.__copymapfile = \
+                self.__config["metadata_copy_map_file"].format(
+                    homepath=self.__homepath)
         if "oned_in_metadata" in self.__config.keys():
             self.__oned = self.__config["oned_in_metadata"]
         if "add_empty_units" in self.__config.keys():

--- a/test/config/myconfig_local.yaml
+++ b/test/config/myconfig_local.yaml
@@ -18,4 +18,4 @@ max_scandir_depth: 1
 dataset_pid_prefix: ""
 datasets_filename_pattern: "scicat-datasets-{hostname}-{beamtimeid}.lst"
 ingested_datasets_filename_pattern: "scicat-datasets-{hostname}-{beamtimeid}.lst"
-# metadata_copy_map_file: "/home/jkotan/scicat/scingestor/test/config/metadata-copy-map.lst"
+# metadata_copy_map_file: "{homepath}/scicat/scingestor/test/config/metadata-copy-map.lst"


### PR DESCRIPTION
It resolves #172 by allowing to use {homepath} in metadata_copy_map_file