### PR TITLE
Issue 223: Do not ingest an attachment when the corresponding dataset pid is missing

### DIFF
--- a/scingestor/datasetIngestor.py
+++ b/scingestor/datasetIngestor.py
@@ -918,6 +918,7 @@ class DatasetIngestor:
                     url=self.__proposalurl,
                     pid=bid.replace("/", "%2F"),
                     token=token))
+
             if resexists.ok:
                 pexists = json.loads(resexists.content)["exists"]
             else:
@@ -990,6 +991,7 @@ class DatasetIngestor:
                     url=self.__dataseturl,
                     pid=npid.replace("/", "%2F"),
                     token=token))
+            # get_logger().info('POST1')
             if resexists.ok:
                 pexist = json.loads(
                     resexists.content)["exists"]
@@ -1008,6 +1010,7 @@ class DatasetIngestor:
             % (self.__dataseturl, token),
             headers=self.__headers,
             data=nmeta)
+        # get_logger().info('POST2')
         if response.ok:
             return mdic["pid"]
         else:
@@ -1039,6 +1042,7 @@ class DatasetIngestor:
                 token=token),
             headers=self.__headers,
             data=nmeta)
+        # get_logger().info('PATCH1')
         if response.ok:
             return mdct["pid"]
         else:
@@ -1106,6 +1110,7 @@ class DatasetIngestor:
                             url=self.__dataseturl,
                             pid=pid.replace("/", "%2F"),
                             token=token))
+                    # get_logger().info('INGEST 3')
                     if resds.ok:
                         dsmeta = json.loads(resds.content)
                         mdic = dict(mdct)
@@ -1190,6 +1195,7 @@ class DatasetIngestor:
                 url.format(pid=dsid, token=token),
                 headers=self.__headers,
                 data=metadata)
+            # get_logger().info('INGEST ATTACH 1')
             if response.ok:
                 return True
             else:
@@ -1240,6 +1246,7 @@ class DatasetIngestor:
                     url=self.__datablockurl,
                     pid=did.replace("/", "%2F"),
                     token=token))
+            # get_logger().info('GET DEL 1')
             if response.ok:
                 return True
             else:

--- a/scingestor/datasetIngestor.py
+++ b/scingestor/datasetIngestor.py
@@ -1607,10 +1607,15 @@ class DatasetIngestor:
                 if ads and reingest_attachment:
                     if pid is None and adss and adss[0]:
                         pid = self._get_pid(adss[0])
-                    dastatus = self._ingest_attachment_metadata(
-                        ads, pid, token)
-                    get_logger().info(
-                        "DatasetIngestor: Ingest attachment: %s" % (ads))
+                    if not pid:
+                        get_logger().error(
+                            "DatasetIngestor: No dataset pid "
+                            "for the attachment found: %s" % (ads))
+                    else:
+                        dastatus = self._ingest_attachment_metadata(
+                            ads, pid, token)
+                        get_logger().info(
+                            "DatasetIngestor: Ingest attachment: %s" % (ads))
         mtmda = 0
         if ads:
             mtmda = os.path.getmtime(ads)

--- a/scingestor/datasetIngestor.py
+++ b/scingestor/datasetIngestor.py
@@ -991,7 +991,6 @@ class DatasetIngestor:
                     url=self.__dataseturl,
                     pid=npid.replace("/", "%2F"),
                     token=token))
-            # get_logger().info('POST1')
             if resexists.ok:
                 pexist = json.loads(
                     resexists.content)["exists"]
@@ -1010,7 +1009,6 @@ class DatasetIngestor:
             % (self.__dataseturl, token),
             headers=self.__headers,
             data=nmeta)
-        # get_logger().info('POST2')
         if response.ok:
             return mdic["pid"]
         else:
@@ -1042,7 +1040,6 @@ class DatasetIngestor:
                 token=token),
             headers=self.__headers,
             data=nmeta)
-        # get_logger().info('PATCH1')
         if response.ok:
             return mdct["pid"]
         else:
@@ -1110,7 +1107,6 @@ class DatasetIngestor:
                             url=self.__dataseturl,
                             pid=pid.replace("/", "%2F"),
                             token=token))
-                    # get_logger().info('INGEST 3')
                     if resds.ok:
                         dsmeta = json.loads(resds.content)
                         mdic = dict(mdct)
@@ -1195,7 +1191,6 @@ class DatasetIngestor:
                 url.format(pid=dsid, token=token),
                 headers=self.__headers,
                 data=metadata)
-            # get_logger().info('INGEST ATTACH 1')
             if response.ok:
                 return True
             else:
@@ -1246,7 +1241,6 @@ class DatasetIngestor:
                     url=self.__datablockurl,
                     pid=did.replace("/", "%2F"),
                     token=token))
-            # get_logger().info('GET DEL 1')
             if response.ok:
                 return True
             else:

--- a/scingestor/datasetIngestor.py
+++ b/scingestor/datasetIngestor.py
@@ -1287,7 +1287,8 @@ class DatasetIngestor:
                 raise Exception(
                     "Wrong SC proposalId %s for DESY beamtimeId %s in %s"
                     % (mt["proposalId"], self.__bid, metafile))
-            if not mt["pid"].startswith("%s/" % (self.__bid)):
+            if not mt['pid'] or \
+               not mt["pid"].startswith("%s/" % (self.__bid)):
                 raise Exception(
                     "Wrong pid %s for DESY beamtimeId %s in  %s"
                     % (mt["pid"], self.__bid, metafile))
@@ -1338,7 +1339,7 @@ class DatasetIngestor:
             with open(metafile) as fl:
                 smt = fl.read()
                 mt = json.loads(smt)
-            if not pid.startswith(self.__bid):
+            if not pid or not pid.startswith(self.__bid):
                 raise Exception(
                     "Wrong origdatablock datasetId %s for DESY beamtimeId "
                     "%s in  %s"
@@ -1371,7 +1372,7 @@ class DatasetIngestor:
                 smt = fl.read()
                 mt = json.loads(smt)
             if "datasetId" in mt:
-                if not pid.startswith(self.__bid):
+                if not pid or not pid.startswith(self.__bid):
                     raise Exception(
                         "Wrong attachment datasetId %s for DESY beamtimeId "
                         "%s in  %s"

--- a/scingestor/modelIngest.py
+++ b/scingestor/modelIngest.py
@@ -159,11 +159,9 @@ class ModelIngest:
             "%s?access_token=%s" % (self.__modelurl, token),
             headers=self.__headers,
             data=metadata)
-        if response.ok:
-            return True
-        else:
+        if not response.ok:
             raise Exception("%s" % response.text)
-        return False
+        return True
 
     def get_token(self):
         """ provides ingestor token

--- a/scingestor/modelIngest.py
+++ b/scingestor/modelIngest.py
@@ -181,7 +181,7 @@ class ModelIngest:
                 raise Exception("%s" % response.text)
         except Exception as e:
             get_logger().error(
-                'DatasetIngestor: %s' % (str(e)))
+                'ModelIngestor: %s' % (str(e)))
         return ""
 
 

--- a/test/DatasetIngest_test.py
+++ b/test/DatasetIngest_test.py
@@ -1020,6 +1020,276 @@ optional arguments:
             if os.path.isdir(fdirname):
                 shutil.rmtree(fdirname)
 
+    def test_datasetfile_exist_attachment_server_error(self):
+        fun = sys._getframe().f_code.co_name
+        # print("Run: %s.%s() " % (self.__class__.__name__, fun))
+        dirname = "test_current"
+        while os.path.exists(dirname):
+            dirname = dirname + '_1'
+        fdirname = os.path.abspath(dirname)
+        fsubdirname = os.path.abspath(os.path.join(dirname, "raw"))
+        fsubdirname2 = os.path.abspath(os.path.join(fsubdirname, "special"))
+        btmeta = "bt-mt-99001234.jsn"
+        dslist = "sc-ds-99001234.lst"
+        idslist = "sc-ids-99001234.lst"
+        wrongdslist = "sc-ds-99001235.lst"
+        jatt = "myscan_00002.attachment.json"
+        source = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                              "config",
+                              btmeta)
+        lsource = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                               "config",
+                               dslist)
+        wlsource = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                                "config",
+                                wrongdslist)
+        asource = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                               "config",
+                               jatt)
+        fullbtmeta = os.path.join(fdirname, btmeta)
+        fdslist = os.path.join(fsubdirname2, dslist)
+        fidslist = os.path.join(fsubdirname2, idslist)
+        credfile = os.path.join(fdirname, 'pwd')
+        url = 'http://localhost:8881'
+        vardir = "/"
+        cred = "12342345"
+        os.mkdir(fdirname)
+        with open(credfile, "w") as cf:
+            cf.write(cred)
+
+        cfg = 'beamtime_dirs:\n' \
+            '  - "{basedir}"\n' \
+            'beamtime_filename_prefix: "bt-mt-"\n' \
+            'beamtime_filename_postfix: ".jsn"\n' \
+            'datasets_filename_pattern: "sc-ds-{{beamtimeid}}.lst"\n' \
+            'ingest_dataset_attachment: true\n' \
+            'ingested_datasets_filename_pattern: ' \
+            '"sc-ids-{{beamtimeid}}.lst"\n' \
+            'log_generator_commands: true\n' \
+            'inotify_timeout: 0.2\n' \
+            'get_event_timeout: 0.02\n' \
+            'ingestion_delay_time: 2\n' \
+            'max_request_tries_number: 10\n' \
+            'recheck_beamtime_file_interval: 1000\n' \
+            'recheck_dataset_list_interval: 1000\n' \
+            'scicat_url: "{url}"\n' \
+            'ingestor_var_dir: "{vardir}"\n' \
+            'ingestor_credential_file: "{credfile}"\n'.format(
+                basedir=fdirname, url=url, vardir=vardir, credfile=credfile)
+
+        cfgfname = "%s_%s.yaml" % (self.__class__.__name__, fun)
+        with open(cfgfname, "w+") as cf:
+            cf.write(cfg)
+        commands = [("scicat_dataset_ingest  -c %s"
+                     % cfgfname).split(),
+                    ("scicat_dataset_ingest --config %s"
+                     % cfgfname).split()]
+        # commands.pop()
+        try:
+            for cmd in commands:
+                os.mkdir(fsubdirname)
+                os.mkdir(fsubdirname2)
+                shutil.copy(source, fdirname)
+                shutil.copy(lsource, fsubdirname2)
+                shutil.copy(wlsource, fsubdirname)
+                shutil.copy(asource, fsubdirname2)
+
+                self.__server.reset()
+                self.__server.error_requests = [10]
+                if os.path.exists(fidslist):
+                    os.remove(fidslist)
+                vl, er = self.runtest(cmd)
+                ser = er.split("\n")
+                seri = [ln for ln in ser if not ln.startswith("127.0.0.1")]
+                # print(vl)
+                # print(er)
+                # sero = [ln for ln in ser if ln.startswith("127.0.0.1")]
+                self.assertEqual(
+                    'INFO : DatasetIngest: beamtime path: {basedir}\n'
+                    'INFO : DatasetIngest: beamtime file: '
+                    'bt-mt-99001234.jsn\n'
+                    'INFO : DatasetIngest: dataset list: {dslist}\n'
+                    'INFO : DatasetIngestor: Checking: {dslist} {sc1}\n'
+                    'INFO : DatasetIngestor: Generating metadata: '
+                    '{sc1} {subdir2}/{sc1}.scan.json\n'
+                    'INFO : DatasetIngestor: Generating dataset command: '
+                    'nxsfileinfo metadata  -o {subdir2}/{sc1}.scan.json  '
+                    '-c 99001234-dmgt,99001234-clbt,99001234-part,'
+                    'p00dmgt,p00staff -w 99001234-dmgt '
+                    '-b {btmeta} '
+                    '-p 99001234/myscan_00001'
+                    ' -r raw/special  --add-empty-units \n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock metadata:'
+                    ' {sc1} {subdir2}/{sc1}.origdatablock.json\n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock command: '
+                    'nxsfileinfo origdatablock  '
+                    '-s *.pyc,*.origdatablock.json,*.scan.json,'
+                    '*.attachment.json,*~  '
+                    '-p /99001234/myscan_00001  -w 99001234-dmgt '
+                    '-c 99001234-dmgt,99001234-clbt,99001234-part,'
+                    'p00dmgt,p00staff '
+                    '-o {subdir2}/{sc1}.origdatablock.json  '
+                    '{subdir2}/{sc1} \n'
+                    'INFO : DatasetIngestor: Check if dataset exists: '
+                    '/99001234/{sc1}\n'
+                    'INFO : DatasetIngestor: Post the dataset: '
+                    '/99001234/{sc1}\n'
+                    'INFO : DatasetIngestor: Ingest dataset: '
+                    '{subdir2}/{sc1}.scan.json\n'
+                    'INFO : DatasetIngestor: Ingest origdatablock: '
+                    '{subdir2}/{sc1}.origdatablock.json\n'
+                    'INFO : DatasetIngestor: Checking: {dslist} {sc2}\n'
+                    'INFO : DatasetIngestor: Generating metadata: '
+                    '{sc2} {subdir2}/{sc2}.scan.json\n'
+                    'INFO : DatasetIngestor: Generating dataset command: '
+                    'nxsfileinfo metadata  -o {subdir2}/{sc2}.scan.json  '
+                    '-c 99001234-dmgt,99001234-clbt,99001234-part,'
+                    'p00dmgt,p00staff -w 99001234-dmgt '
+                    '-b {btmeta} '
+                    '-p 99001234/myscan_00002'
+                    ' -r raw/special  --add-empty-units \n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock metadata:'
+                    ' {sc2} {subdir2}/{sc2}.origdatablock.json\n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock command: '
+                    'nxsfileinfo origdatablock  '
+                    '-s *.pyc,*.origdatablock.json,*.scan.json,'
+                    '*.attachment.json,*~  '
+                    '-p /99001234/myscan_00002  -w 99001234-dmgt '
+                    '-c 99001234-dmgt,99001234-clbt,99001234-part,'
+                    'p00dmgt,p00staff '
+                    '-o {subdir2}/{sc2}.origdatablock.json  '
+                    '{subdir2}/{sc2} \n'
+                    'INFO : DatasetIngestor: Check if dataset exists: '
+                    '/99001234/{sc2}\n'
+                    'INFO : DatasetIngestor: Post the dataset: '
+                    '/99001234/{sc2}\n'
+                    'INFO : DatasetIngestor: Ingest dataset: '
+                    '{subdir2}/{sc2}.scan.json\n'
+                    'INFO : DatasetIngestor: Ingest origdatablock: '
+                    '{subdir2}/{sc2}.origdatablock.json\n'
+                    'ERROR : DatasetIngestor: '
+                    '{{"Error": "Internal Error"}}\n'
+                    'INFO : DatasetIngestor: Ingest attachment: '
+                    '{subdir2}/{sc2}.attachment.json\n'
+                    .format(basedir=fdirname,
+                            subdir2=fsubdirname2,
+                            dslist=fdslist,
+                            btmeta=fullbtmeta,
+                            sc1='myscan_00001', sc2='myscan_00002'),
+                    "\n".join(seri))
+                self.assertEqual(
+                    "Login: ingestor\n"
+                    "RawDatasets: 99001234/myscan_00001\n"
+                    "OrigDatablocks: /99001234/myscan_00001\n"
+                    "RawDatasets: 99001234/myscan_00002\n"
+                    "OrigDatablocks: /99001234/myscan_00002\n", vl)
+                self.assertEqual(len(self.__server.userslogin), 1)
+                self.assertEqual(
+                    self.__server.userslogin[0],
+                    b'{"username": "ingestor", "password": "12342345"}')
+                self.assertEqual(len(self.__server.datasets), 2)
+                self.myAssertDict(
+                    json.loads(self.__server.datasets[0]),
+                    {'contactEmail': 'appuser@fake.com',
+                     'createdAt': '2022-05-14 11:54:29',
+                     'creationLocation': '/DESY/PETRA III/P00',
+                     'instrumentId': '/petra3/p00',
+                     'description': 'H20 distribution',
+                     'creationTime': '2022-05-19 09:00:00',
+                     'endTime': '2022-05-19 09:00:00',
+                     'isPublished': False,
+                     'techniques': [],
+                     'owner': 'Smithson',
+                     'ownerGroup': '99001234-dmgt',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'ownerEmail': 'peter.smithson@fake.de',
+                     'pid': '99001234/myscan_00001',
+                     'datasetName': 'myscan_00001',
+                     'principalInvestigator': 'appuser@fake.com',
+                     'proposalId': '99001234',
+                     'scientificMetadata': {
+                         'DOOR_proposalId': '99991173',
+                         'beamtimeId': '99001234'},
+                     'sourceFolder':
+                     '/asap3/petra3/gpfs/p00/2022/data/9901234/raw/special',
+                     'type': 'raw',
+                     'updatedAt': '2022-05-14 11:54:29'},
+                    skip=['creationTime'])
+                self.myAssertDict(
+                    json.loads(self.__server.datasets[1]),
+                    {'contactEmail': 'appuser@fake.com',
+                     'createdAt': '2022-05-14 11:54:29',
+                     'instrumentId': '/petra3/p00',
+                     'creationLocation': '/DESY/PETRA III/P00',
+                     'description': 'H20 distribution',
+                     'creationTime': '2022-05-19 09:00:00',
+                     'endTime': '2022-05-19 09:00:00',
+                     'isPublished': False,
+                     'techniques': [],
+                     'owner': 'Smithson',
+                     'ownerGroup': '99001234-dmgt',
+                     'ownerEmail': 'peter.smithson@fake.de',
+                     'pid': '99001234/myscan_00002',
+                     'datasetName': 'myscan_00002',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'principalInvestigator': 'appuser@fake.com',
+                     'proposalId': '99001234',
+                     'scientificMetadata': {
+                         'DOOR_proposalId': '99991173',
+                         'beamtimeId': '99001234'},
+                     'sourceFolder':
+                     '/asap3/petra3/gpfs/p00/2022/data/9901234/raw/special',
+                     'type': 'raw',
+                     'updatedAt': '2022-05-14 11:54:29'},
+                    skip=['creationTime'])
+                self.assertEqual(len(self.__server.origdatablocks), 2)
+                self.myAssertDict(
+                    json.loads(self.__server.origdatablocks[0]),
+                    {'dataFileList': [
+                        {'gid': 'jkotan',
+                         'path': 'myscan_00001.scan.json',
+                         'perm': '-rw-r--r--',
+                         'size': 629,
+                         'time': '2022-07-05T19:07:16.683673+0200',
+                         'uid': 'jkotan'}],
+                     'ownerGroup': '99001234-dmgt',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'datasetId': '/99001234/myscan_00001',
+                     'size': 629}, skip=["dataFileList", "size"])
+                self.myAssertDict(
+                    json.loads(self.__server.origdatablocks[1]),
+                    {'dataFileList': [
+                        {'gid': 'jkotan',
+                         'path': 'myscan_00001.scan.json',
+                         'perm': '-rw-r--r--',
+                         'size': 629,
+                         'time': '2022-07-05T19:07:16.683673+0200',
+                         'uid': 'jkotan'}],
+                     'datasetId': '/99001234/myscan_00002',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'ownerGroup': '99001234-dmgt',
+                     'size': 629}, skip=["dataFileList", "size"])
+                self.assertEqual(len(self.__server.attachments), 0)
+                if os.path.isdir(fsubdirname):
+                    shutil.rmtree(fsubdirname)
+        finally:
+            if os.path.exists(cfgfname):
+                os.remove(cfgfname)
+            if os.path.isdir(fdirname):
+                shutil.rmtree(fdirname)
+
     def test_datasetfile_exist_attachment_wrong_pid(self):
         fun = sys._getframe().f_code.co_name
         # print("Run: %s.%s() " % (self.__class__.__name__, fun))
@@ -2379,6 +2649,558 @@ optional arguments:
             if os.path.isdir(fdirname):
                 shutil.rmtree(fdirname)
 
+    def test_datasetfile_jsonchange_patch_server_error(self):
+        fun = sys._getframe().f_code.co_name
+        # print("Run: %s.%s() " % (self.__class__.__name__, fun))
+        dirname = "test_current"
+        while os.path.exists(dirname):
+            dirname = dirname + '_1'
+        fdirname = os.path.abspath(dirname)
+        fsubdirname = os.path.abspath(os.path.join(dirname, "raw"))
+        fsubdirname2 = os.path.abspath(os.path.join(fsubdirname, "special"))
+        btmeta = "beamtime-metadata-99001234.json"
+        dslist = "scicat-datasets-99001234.lst"
+        idslist = "scicat-ingested-datasets-99001234.lst"
+        wrongdslist = "scicat-datasets-99001235.lst"
+        source = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                              "config",
+                              btmeta)
+        lsource = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                               "config",
+                               dslist)
+        wlsource = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                                "config",
+                                wrongdslist)
+        # fullbtmeta = os.path.join(fdirname, btmeta)
+        fdslist = os.path.join(fsubdirname2, dslist)
+        fidslist = os.path.join(fsubdirname2, idslist)
+        credfile = os.path.join(fdirname, 'pwd')
+        url = 'http://localhost:8881'
+        vardir = "/"
+        cred = "12342345"
+        os.mkdir(fdirname)
+        with open(credfile, "w") as cf:
+            cf.write(cred)
+
+        cfg = 'beamtime_dirs:\n' \
+            '  - "{basedir}"\n' \
+            'scicat_url: "{url}"\n' \
+            'log_generator_commands: true\n' \
+            'ingestor_var_dir: "{vardir}"\n' \
+            'ingestor_credential_file: "{credfile}"\n'.format(
+                basedir=fdirname, url=url, vardir=vardir, credfile=credfile)
+
+        cfgfname = "%s_%s.yaml" % (self.__class__.__name__, fun)
+        with open(cfgfname, "w+") as cf:
+            cf.write(cfg)
+        commands = [('scicat_dataset_ingest -c %s'
+                     % cfgfname).split(),
+                    ('scicat_dataset_ingest --config %s'
+                     % cfgfname).split()]
+        # commands.pop()
+        try:
+            for cmd in commands:
+                os.mkdir(fsubdirname)
+                os.mkdir(fsubdirname2)
+                shutil.copy(source, fdirname)
+                shutil.copy(lsource, fsubdirname2)
+                shutil.copy(wlsource, fsubdirname)
+                self.__server.reset()
+                self.__server.error_requests = [13]
+                if os.path.exists(fidslist):
+                    os.remove(fidslist)
+
+                vl, er = self.runtest(cmd)
+
+                scfname = "%s/%s.scan.json" % (fsubdirname2, 'myscan_00001')
+                odbfname = "%s/%s.origdatablock.json" \
+                    % (fsubdirname2, 'myscan_00002')
+
+                scdict = {}
+                with open(scfname, "r") as fl:
+                    scn = fl.read()
+                    scdict = json.loads(scn)
+                scdict["owner"] = "NewOwner"
+                scdict["contactEmail"] = "new.owner@ggg.gg"
+                scdict["techniques"] = [
+                   {
+                       'name': 'small angle x-ray scattering',
+                       'pid':
+                       'http://purl.org/pan-science/PaNET/PaNET01188'
+                   }
+                ]
+                with open(scfname, "w") as fl:
+                    fl.write(json.dumps(scdict))
+
+                scdict = {}
+                with open(odbfname, "r") as fl:
+                    scn = fl.read()
+                    scdict = json.loads(scn)
+                scdict["size"] = 123123
+                with open(odbfname, "w") as fl:
+                    fl.write(json.dumps(scdict))
+
+                vl, er = self.runtest(cmd)
+
+                ser = er.split("\n")
+                seri = [ln for ln in ser if not ln.startswith("127.0.0.1")]
+                # print(er)
+                # sero = [ln for ln in ser if ln.startswith("127.0.0.1")]
+                self.assertEqual(
+                    'INFO : DatasetIngest: beamtime path: {basedir}\n'
+                    'INFO : DatasetIngest: beamtime file: '
+                    'beamtime-metadata-99001234.json\n'
+                    'INFO : DatasetIngest: dataset list: {dslist}\n'
+                    'INFO : DatasetIngestor: Checking: {dslist} {sc1}\n'
+                    'INFO : DatasetIngestor: Checking origdatablock metadata:'
+                    ' {sc1} {subdir2}/{sc1}.origdatablock.json\n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock command: '
+                    'nxsfileinfo origdatablock  '
+                    '-s *.pyc,*.origdatablock.json,*.scan.json,'
+                    '*.attachment.json,*~  '
+                    '-w 99001234-dmgt '
+                    '-c 99001234-dmgt,99001234-clbt,99001234-part,'
+                    'p00dmgt,p00staff '
+                    '-p /99001234/myscan_00001  '
+                    '{subdir2}/{sc1} \n'
+                    'INFO : DatasetIngestor: Check if dataset exists: '
+                    '/99001234/{sc1}\n'
+                    'INFO : DatasetIngestor: Find the dataset by id: '
+                    '/99001234/{sc1}\n'
+                    'INFO : DatasetIngestor: '
+                    'Patch scientificMetadata of dataset: '
+                    '/99001234/{sc1}\n'
+                    'ERROR : DatasetIngestor: '
+                    '{{"Error": "Internal Error"}}\n'
+                    'INFO : DatasetIngestor: Ingest dataset: '
+                    '{subdir2}/{sc1}.scan.json\n'
+                    'INFO : DatasetIngestor: Checking: {dslist} {sc2}\n'
+                    'INFO : DatasetIngestor: Checking origdatablock metadata:'
+                    ' {sc2} {subdir2}/{sc2}.origdatablock.json\n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock command: '
+                    'nxsfileinfo origdatablock  '
+                    '-s *.pyc,*.origdatablock.json,*.scan.json,'
+                    '*.attachment.json,*~  '
+                    '-w 99001234-dmgt '
+                    '-c 99001234-dmgt,99001234-clbt,99001234-part,'
+                    'p00dmgt,p00staff '
+                    '-p /99001234/myscan_00002  '
+                    '{subdir2}/{sc2} \n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock metadata:'
+                    ' {sc2} {subdir2}/{sc2}.origdatablock.json\n'
+                    'INFO : DatasetIngestor: Ingest origdatablock:'
+                    ' {subdir2}/{sc2}.origdatablock.json\n'
+                    .format(basedir=fdirname,
+                            subdir2=fsubdirname2,
+                            dslist=fdslist,
+                            sc1='myscan_00001', sc2='myscan_00002'),
+                    "\n".join(seri))
+                self.assertEqual(
+                    "Login: ingestor\n"
+                    "OrigDatablocks: delete /99001234/myscan_00002\n"
+                    "OrigDatablocks: /99001234/myscan_00002\n",
+                    vl)
+                self.assertEqual(len(self.__server.userslogin), 2)
+                self.assertEqual(
+                    self.__server.userslogin[0],
+                    b'{"username": "ingestor", "password": "12342345"}')
+                self.assertEqual(
+                    self.__server.userslogin[1],
+                    b'{"username": "ingestor", "password": "12342345"}')
+                # self.assertEqual(
+                #     self.__server.userslogin[2],
+                #     b'{"username": "ingestor", "password": "12342345"}')
+                self.assertEqual(len(self.__server.datasets), 2)
+                self.myAssertDict(
+                    json.loads(self.__server.datasets[0]),
+                    {'contactEmail': 'appuser@fake.com',
+                     'createdAt': '2022-05-14 11:54:29',
+                     'instrumentId': '/petra3/p00',
+                     'creationLocation': '/DESY/PETRA III/P00',
+                     'description': 'H20 distribution',
+                     'creationTime': '2022-05-19 09:00:00',
+                     'endTime': '2022-05-19 09:00:00',
+                     'isPublished': False,
+                     'techniques': [],
+                     'owner': 'Smithson',
+                     'ownerGroup': '99001234-dmgt',
+                     'ownerEmail': 'peter.smithson@fake.de',
+                     'pid': '99001234/myscan_00001',
+                     'datasetName': 'myscan_00001',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'principalInvestigator': 'appuser@fake.com',
+                     'proposalId': '99001234',
+                     'scientificMetadata': {
+                         'DOOR_proposalId': '99991173',
+                         'beamtimeId': '99001234'},
+                     'sourceFolder':
+                     '/asap3/petra3/gpfs/p00/2022/data/9901234/raw/special',
+                     'type': 'raw',
+                     'updatedAt': '2022-05-14 11:54:29'},
+                    skip=['creationTime'])
+                self.myAssertDict(
+                    json.loads(self.__server.datasets[1]),
+                    {'contactEmail': 'appuser@fake.com',
+                     'createdAt': '2022-05-14 11:54:29',
+                     'creationLocation': '/DESY/PETRA III/P00',
+                     'instrumentId': '/petra3/p00',
+                     'description': 'H20 distribution',
+                     'creationTime': '2022-05-19 09:00:00',
+                     'endTime': '2022-05-19 09:00:00',
+                     'isPublished': False,
+                     'owner': 'Smithson',
+                     'techniques': [],
+                     'ownerEmail': 'peter.smithson@fake.de',
+                     'ownerGroup': '99001234-dmgt',
+                     'pid': '99001234/myscan_00002',
+                     'datasetName': 'myscan_00002',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'principalInvestigator': 'appuser@fake.com',
+                     'proposalId': '99001234',
+                     'scientificMetadata': {
+                         'DOOR_proposalId': '99991173',
+                         'beamtimeId': '99001234'},
+                     'sourceFolder':
+                     '/asap3/petra3/gpfs/p00/2022/data/9901234/raw/special',
+                     'type': 'raw',
+                     'updatedAt': '2022-05-14 11:54:29'},
+                    skip=['creationTime'])
+                self.assertEqual(len(self.__server.origdatablocks), 3)
+                self.myAssertDict(
+                    json.loads(self.__server.origdatablocks[0]),
+                    {'dataFileList': [
+                        {'gid': 'jkotan',
+                         'path': 'myscan_00001.scan.json',
+                         'perm': '-rw-r--r--',
+                         'size': 629,
+                         'time': '2022-07-05T19:07:16.683673+0200',
+                         'uid': 'jkotan'}],
+                     'datasetId': '/99001234/myscan_00001',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'ownerGroup': '99001234-dmgt',
+                     'size': 629}, skip=["dataFileList", "size"])
+                self.myAssertDict(
+                    json.loads(self.__server.origdatablocks[1]),
+                    {'dataFileList': [
+                        {'gid': 'jkotan',
+                         'path': 'myscan_00001.scan.json',
+                         'perm': '-rw-r--r--',
+                         'size': 629,
+                         'time': '2022-07-05T19:07:16.683673+0200',
+                         'uid': 'jkotan'}],
+                     'datasetId': '/99001234/myscan_00002',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'ownerGroup': '99001234-dmgt',
+                     'size': 629}, skip=["dataFileList", "size"])
+                self.myAssertDict(
+                    json.loads(self.__server.origdatablocks[2]),
+                    {'dataFileList': [
+                        {'gid': 'jkotan',
+                         'path': 'myscan_00001.scan.json',
+                         'perm': '-rw-r--r--',
+                         'size': 629,
+                         'time': '2022-07-05T19:07:16.683673+0200',
+                         'uid': 'jkotan'}],
+                     'datasetId': '/99001234/myscan_00002',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'ownerGroup': '99001234-dmgt',
+                     'size': 629}, skip=["dataFileList", "size"])
+                if os.path.isdir(fsubdirname):
+                    shutil.rmtree(fsubdirname)
+        finally:
+            if os.path.exists(cfgfname):
+                os.remove(cfgfname)
+            if os.path.isdir(fdirname):
+                shutil.rmtree(fdirname)
+
+    def test_datasetfile_jsonchange_server_errors(self):
+        fun = sys._getframe().f_code.co_name
+        # print("Run: %s.%s() " % (self.__class__.__name__, fun))
+        dirname = "test_current"
+        while os.path.exists(dirname):
+            dirname = dirname + '_1'
+        fdirname = os.path.abspath(dirname)
+        fsubdirname = os.path.abspath(os.path.join(dirname, "raw"))
+        fsubdirname2 = os.path.abspath(os.path.join(fsubdirname, "special"))
+        btmeta = "beamtime-metadata-99001234.json"
+        dslist = "scicat-datasets-99001234.lst"
+        idslist = "scicat-ingested-datasets-99001234.lst"
+        wrongdslist = "scicat-datasets-99001235.lst"
+        source = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                              "config",
+                              btmeta)
+        lsource = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                               "config",
+                               dslist)
+        wlsource = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                                "config",
+                                wrongdslist)
+        # fullbtmeta = os.path.join(fdirname, btmeta)
+        fdslist = os.path.join(fsubdirname2, dslist)
+        fidslist = os.path.join(fsubdirname2, idslist)
+        credfile = os.path.join(fdirname, 'pwd')
+        url = 'http://localhost:8881'
+        vardir = "/"
+        cred = "12342345"
+        os.mkdir(fdirname)
+        with open(credfile, "w") as cf:
+            cf.write(cred)
+
+        cfg = 'beamtime_dirs:\n' \
+            '  - "{basedir}"\n' \
+            'scicat_url: "{url}"\n' \
+            'log_generator_commands: true\n' \
+            'ingestor_var_dir: "{vardir}"\n' \
+            'ingestor_credential_file: "{credfile}"\n'.format(
+                basedir=fdirname, url=url, vardir=vardir, credfile=credfile)
+
+        cfgfname = "%s_%s.yaml" % (self.__class__.__name__, fun)
+        with open(cfgfname, "w+") as cf:
+            cf.write(cfg)
+        commands = [('scicat_dataset_ingest -c %s'
+                     % cfgfname).split(),
+                    ('scicat_dataset_ingest --config %s'
+                     % cfgfname).split()]
+        # commands.pop()
+        try:
+            for cmd in commands:
+                os.mkdir(fsubdirname)
+                os.mkdir(fsubdirname2)
+                shutil.copy(source, fdirname)
+                shutil.copy(lsource, fsubdirname2)
+                shutil.copy(wlsource, fsubdirname)
+                self.__server.reset()
+                self.__server.error_requests = [12, 14]
+                if os.path.exists(fidslist):
+                    os.remove(fidslist)
+
+                vl, er = self.runtest(cmd)
+
+                scfname = "%s/%s.scan.json" % (fsubdirname2, 'myscan_00001')
+                odbfname = "%s/%s.origdatablock.json" \
+                    % (fsubdirname2, 'myscan_00002')
+
+                scdict = {}
+                with open(scfname, "r") as fl:
+                    scn = fl.read()
+                    scdict = json.loads(scn)
+                scdict["owner"] = "NewOwner"
+                scdict["contactEmail"] = "new.owner@ggg.gg"
+                scdict["techniques"] = [
+                   {
+                       'name': 'small angle x-ray scattering',
+                       'pid':
+                       'http://purl.org/pan-science/PaNET/PaNET01188'
+                   }
+                ]
+                with open(scfname, "w") as fl:
+                    fl.write(json.dumps(scdict))
+
+                scdict = {}
+                with open(odbfname, "r") as fl:
+                    scn = fl.read()
+                    scdict = json.loads(scn)
+                scdict["size"] = 123123
+                with open(odbfname, "w") as fl:
+                    fl.write(json.dumps(scdict))
+
+                vl, er = self.runtest(cmd)
+
+                ser = er.split("\n")
+                seri = [ln for ln in ser if not ln.startswith("127.0.0.1")]
+                # print(er)
+                # sero = [ln for ln in ser if ln.startswith("127.0.0.1")]
+                self.assertEqual(
+                    'INFO : DatasetIngest: beamtime path: {basedir}\n'
+                    'INFO : DatasetIngest: beamtime file: '
+                    'beamtime-metadata-99001234.json\n'
+                    'INFO : DatasetIngest: dataset list: {dslist}\n'
+                    'INFO : DatasetIngestor: Checking: {dslist} {sc1}\n'
+                    'INFO : DatasetIngestor: Checking origdatablock metadata:'
+                    ' {sc1} {subdir2}/{sc1}.origdatablock.json\n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock command: '
+                    'nxsfileinfo origdatablock  '
+                    '-s *.pyc,*.origdatablock.json,*.scan.json,'
+                    '*.attachment.json,*~  '
+                    '-w 99001234-dmgt '
+                    '-c 99001234-dmgt,99001234-clbt,99001234-part,'
+                    'p00dmgt,p00staff '
+                    '-p /99001234/myscan_00001  '
+                    '{subdir2}/{sc1} \n'
+                    'INFO : DatasetIngestor: Check if dataset exists: '
+                    '/99001234/{sc1}\n'
+                    'INFO : DatasetIngestor: Find the dataset by id: '
+                    '/99001234/{sc1}\n'
+                    'ERROR : DatasetIngestor: '
+                    '{{"Error": "Internal Error"}}\n'
+                    'INFO : DatasetIngestor: Ingest dataset: '
+                    '{subdir2}/{sc1}.scan.json\n'
+                    'INFO : DatasetIngestor: Checking: {dslist} {sc2}\n'
+                    'INFO : DatasetIngestor: Checking origdatablock metadata:'
+                    ' {sc2} {subdir2}/{sc2}.origdatablock.json\n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock command: '
+                    'nxsfileinfo origdatablock  '
+                    '-s *.pyc,*.origdatablock.json,*.scan.json,'
+                    '*.attachment.json,*~  '
+                    '-w 99001234-dmgt '
+                    '-c 99001234-dmgt,99001234-clbt,99001234-part,'
+                    'p00dmgt,p00staff '
+                    '-p /99001234/myscan_00002  '
+                    '{subdir2}/{sc2} \n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock metadata:'
+                    ' {sc2} {subdir2}/{sc2}.origdatablock.json\n'
+                    'ERROR : DatasetIngestor: '
+                    '{{"Error": "Internal Error"}}\n'
+                    'INFO : DatasetIngestor: Ingest origdatablock:'
+                    ' {subdir2}/{sc2}.origdatablock.json\n'
+                    .format(basedir=fdirname,
+                            subdir2=fsubdirname2,
+                            dslist=fdslist,
+                            sc1='myscan_00001', sc2='myscan_00002'),
+                    "\n".join(seri))
+                self.assertEqual(
+                    "Login: ingestor\n"
+                    "OrigDatablocks: /99001234/myscan_00002\n",
+                    vl)
+                self.assertEqual(len(self.__server.userslogin), 2)
+                self.assertEqual(
+                    self.__server.userslogin[0],
+                    b'{"username": "ingestor", "password": "12342345"}')
+                self.assertEqual(
+                    self.__server.userslogin[1],
+                    b'{"username": "ingestor", "password": "12342345"}')
+                # self.assertEqual(
+                #     self.__server.userslogin[2],
+                #     b'{"username": "ingestor", "password": "12342345"}')
+                self.assertEqual(len(self.__server.datasets), 2)
+                self.myAssertDict(
+                    json.loads(self.__server.datasets[0]),
+                    {'contactEmail': 'appuser@fake.com',
+                     'createdAt': '2022-05-14 11:54:29',
+                     'instrumentId': '/petra3/p00',
+                     'creationLocation': '/DESY/PETRA III/P00',
+                     'description': 'H20 distribution',
+                     'creationTime': '2022-05-19 09:00:00',
+                     'endTime': '2022-05-19 09:00:00',
+                     'isPublished': False,
+                     'techniques': [],
+                     'owner': 'Smithson',
+                     'ownerGroup': '99001234-dmgt',
+                     'ownerEmail': 'peter.smithson@fake.de',
+                     'pid': '99001234/myscan_00001',
+                     'datasetName': 'myscan_00001',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'principalInvestigator': 'appuser@fake.com',
+                     'proposalId': '99001234',
+                     'scientificMetadata': {
+                         'DOOR_proposalId': '99991173',
+                         'beamtimeId': '99001234'},
+                     'sourceFolder':
+                     '/asap3/petra3/gpfs/p00/2022/data/9901234/raw/special',
+                     'type': 'raw',
+                     'updatedAt': '2022-05-14 11:54:29'},
+                    skip=['creationTime'])
+                self.myAssertDict(
+                    json.loads(self.__server.datasets[1]),
+                    {'contactEmail': 'appuser@fake.com',
+                     'createdAt': '2022-05-14 11:54:29',
+                     'creationLocation': '/DESY/PETRA III/P00',
+                     'instrumentId': '/petra3/p00',
+                     'description': 'H20 distribution',
+                     'creationTime': '2022-05-19 09:00:00',
+                     'endTime': '2022-05-19 09:00:00',
+                     'isPublished': False,
+                     'owner': 'Smithson',
+                     'techniques': [],
+                     'ownerEmail': 'peter.smithson@fake.de',
+                     'ownerGroup': '99001234-dmgt',
+                     'pid': '99001234/myscan_00002',
+                     'datasetName': 'myscan_00002',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'principalInvestigator': 'appuser@fake.com',
+                     'proposalId': '99001234',
+                     'scientificMetadata': {
+                         'DOOR_proposalId': '99991173',
+                         'beamtimeId': '99001234'},
+                     'sourceFolder':
+                     '/asap3/petra3/gpfs/p00/2022/data/9901234/raw/special',
+                     'type': 'raw',
+                     'updatedAt': '2022-05-14 11:54:29'},
+                    skip=['creationTime'])
+                self.assertEqual(len(self.__server.origdatablocks), 3)
+                self.myAssertDict(
+                    json.loads(self.__server.origdatablocks[0]),
+                    {'dataFileList': [
+                        {'gid': 'jkotan',
+                         'path': 'myscan_00001.scan.json',
+                         'perm': '-rw-r--r--',
+                         'size': 629,
+                         'time': '2022-07-05T19:07:16.683673+0200',
+                         'uid': 'jkotan'}],
+                     'datasetId': '/99001234/myscan_00001',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'ownerGroup': '99001234-dmgt',
+                     'size': 629}, skip=["dataFileList", "size"])
+                self.myAssertDict(
+                    json.loads(self.__server.origdatablocks[1]),
+                    {'dataFileList': [
+                        {'gid': 'jkotan',
+                         'path': 'myscan_00001.scan.json',
+                         'perm': '-rw-r--r--',
+                         'size': 629,
+                         'time': '2022-07-05T19:07:16.683673+0200',
+                         'uid': 'jkotan'}],
+                     'datasetId': '/99001234/myscan_00002',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'ownerGroup': '99001234-dmgt',
+                     'size': 629}, skip=["dataFileList", "size"])
+                self.myAssertDict(
+                    json.loads(self.__server.origdatablocks[2]),
+                    {'dataFileList': [
+                        {'gid': 'jkotan',
+                         'path': 'myscan_00001.scan.json',
+                         'perm': '-rw-r--r--',
+                         'size': 629,
+                         'time': '2022-07-05T19:07:16.683673+0200',
+                         'uid': 'jkotan'}],
+                     'datasetId': '/99001234/myscan_00002',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'ownerGroup': '99001234-dmgt',
+                     'size': 629}, skip=["dataFileList", "size"])
+                if os.path.isdir(fsubdirname):
+                    shutil.rmtree(fsubdirname)
+        finally:
+            if os.path.exists(cfgfname):
+                os.remove(cfgfname)
+            if os.path.isdir(fdirname):
+                shutil.rmtree(fdirname)
+
     def test_datasetfile_jsonchange_corepath(self):
         fun = sys._getframe().f_code.co_name
         # print("Run: %s.%s() " % (self.__class__.__name__, fun))
@@ -3458,6 +4280,558 @@ optional arguments:
                      'size': 629}, skip=["dataFileList", "size"])
                 self.myAssertDict(
                     json.loads(self.__server.origdatablocks[3]),
+                    {'dataFileList': [
+                        {'gid': 'jkotan',
+                         'path': 'myscan_00001.scan.json',
+                         'perm': '-rw-r--r--',
+                         'size': 629,
+                         'time': '2022-07-05T19:07:16.683673+0200',
+                         'uid': 'jkotan'}],
+                     'datasetId': '/99001234/myscan_00002',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'ownerGroup': '99001234-dmgt',
+                     'size': 629}, skip=["dataFileList", "size"])
+                if os.path.isdir(fsubdirname):
+                    shutil.rmtree(fsubdirname)
+        finally:
+            if os.path.exists(cfgfname):
+                os.remove(cfgfname)
+            if os.path.isdir(fdirname):
+                shutil.rmtree(fdirname)
+
+    def test_datasetfile_jsonchange_mixed_post_server_error(self):
+        fun = sys._getframe().f_code.co_name
+        # print("Run: %s.%s() " % (self.__class__.__name__, fun))
+        dirname = "test_current"
+        while os.path.exists(dirname):
+            dirname = dirname + '_1'
+        fdirname = os.path.abspath(dirname)
+        fsubdirname = os.path.abspath(os.path.join(dirname, "raw"))
+        fsubdirname2 = os.path.abspath(os.path.join(fsubdirname, "special"))
+        btmeta = "beamtime-metadata-99001234.json"
+        dslist = "scicat-datasets-99001234.lst"
+        idslist = "scicat-ingested-datasets-99001234.lst"
+        wrongdslist = "scicat-datasets-99001235.lst"
+        source = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                              "config",
+                              btmeta)
+        lsource = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                               "config",
+                               dslist)
+        wlsource = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                                "config",
+                                wrongdslist)
+        # fullbtmeta = os.path.join(fdirname, btmeta)
+        fdslist = os.path.join(fsubdirname2, dslist)
+        fidslist = os.path.join(fsubdirname2, idslist)
+        credfile = os.path.join(fdirname, 'pwd')
+        url = 'http://localhost:8881'
+        vardir = "/"
+        cred = "12342345"
+        os.mkdir(fdirname)
+        with open(credfile, "w") as cf:
+            cf.write(cred)
+
+        cfg = 'beamtime_dirs:\n' \
+            '  - "{basedir}"\n' \
+            'scicat_url: "{url}"\n' \
+            'log_generator_commands: true\n' \
+            'dataset_update_strategy: "mixed"\n' \
+            'ingestor_var_dir: "{vardir}"\n' \
+            'ingestor_credential_file: "{credfile}"\n'.format(
+                basedir=fdirname, url=url, vardir=vardir, credfile=credfile)
+
+        cfgfname = "%s_%s.yaml" % (self.__class__.__name__, fun)
+        with open(cfgfname, "w+") as cf:
+            cf.write(cfg)
+        commands = [('scicat_dataset_ingest -c %s'
+                     % cfgfname).split(),
+                    ('scicat_dataset_ingest --config %s'
+                     % cfgfname).split()]
+        # commands.pop()
+        try:
+            for cmd in commands:
+                os.mkdir(fsubdirname)
+                os.mkdir(fsubdirname2)
+                shutil.copy(source, fdirname)
+                shutil.copy(lsource, fsubdirname2)
+                shutil.copy(wlsource, fsubdirname)
+                self.__server.reset()
+                self.__server.error_requests = [13]
+                if os.path.exists(fidslist):
+                    os.remove(fidslist)
+
+                vl, er = self.runtest(cmd)
+
+                scfname = "%s/%s.scan.json" % (fsubdirname2, 'myscan_00001')
+                odbfname = "%s/%s.origdatablock.json" \
+                    % (fsubdirname2, 'myscan_00002')
+
+                scdict = {}
+                with open(scfname, "r") as fl:
+                    scn = fl.read()
+                    scdict = json.loads(scn)
+                scdict["owner"] = "NewOwner"
+                scdict["contactEmail"] = "new.owner@ggg.gg"
+                scdict["techniques"] = [
+                   {
+                       'name': 'small angle x-ray scattering',
+                       'pid':
+                       'http://purl.org/pan-science/PaNET/PaNET01188'
+                   }
+                ]
+                with open(scfname, "w") as fl:
+                    fl.write(json.dumps(scdict))
+
+                scdict = {}
+                with open(odbfname, "r") as fl:
+                    scn = fl.read()
+                    scdict = json.loads(scn)
+                scdict["size"] = 123123
+                with open(odbfname, "w") as fl:
+                    fl.write(json.dumps(scdict))
+
+                vl, er = self.runtest(cmd)
+
+                ser = er.split("\n")
+                seri = [ln for ln in ser if not ln.startswith("127.0.0.1")]
+                # print(er)
+                # sero = [ln for ln in ser if ln.startswith("127.0.0.1")]
+                self.assertEqual(
+                    'INFO : DatasetIngest: beamtime path: {basedir}\n'
+                    'INFO : DatasetIngest: beamtime file: '
+                    'beamtime-metadata-99001234.json\n'
+                    'INFO : DatasetIngest: dataset list: {dslist}\n'
+                    'INFO : DatasetIngestor: Checking: {dslist} {sc1}\n'
+                    'INFO : DatasetIngestor: Checking origdatablock metadata:'
+                    ' {sc1} {subdir2}/{sc1}.origdatablock.json\n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock command: '
+                    'nxsfileinfo origdatablock  '
+                    '-s *.pyc,*.origdatablock.json,*.scan.json,'
+                    '*.attachment.json,*~  '
+                    '-w 99001234-dmgt '
+                    '-c 99001234-dmgt,99001234-clbt,99001234-part,'
+                    'p00dmgt,p00staff '
+                    '-p /99001234/myscan_00001  '
+                    '{subdir2}/{sc1} \n'
+                    'INFO : DatasetIngestor: Check if dataset exists: '
+                    '/99001234/{sc1}\n'
+                    'INFO : DatasetIngestor: Find the dataset by id: '
+                    '/99001234/{sc1}\n'
+                    'ERROR : DatasetIngestor: '
+                    '{{"Error": "Internal Error"}}\n'
+                    'INFO : DatasetIngestor: Ingest dataset: '
+                    '{subdir2}/{sc1}.scan.json\n'
+                    'INFO : DatasetIngestor: Checking: {dslist} {sc2}\n'
+                    'INFO : DatasetIngestor: Checking origdatablock metadata:'
+                    ' {sc2} {subdir2}/{sc2}.origdatablock.json\n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock command: '
+                    'nxsfileinfo origdatablock  '
+                    '-s *.pyc,*.origdatablock.json,*.scan.json,'
+                    '*.attachment.json,*~  '
+                    '-w 99001234-dmgt '
+                    '-c 99001234-dmgt,99001234-clbt,99001234-part,'
+                    'p00dmgt,p00staff '
+                    '-p /99001234/myscan_00002  '
+                    '{subdir2}/{sc2} \n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock metadata:'
+                    ' {sc2} {subdir2}/{sc2}.origdatablock.json\n'
+                    'INFO : DatasetIngestor: Ingest origdatablock:'
+                    ' {subdir2}/{sc2}.origdatablock.json\n'
+                    .format(basedir=fdirname,
+                            subdir2=fsubdirname2,
+                            dslist=fdslist,
+                            sc1='myscan_00001', sc2='myscan_00002'),
+                    "\n".join(seri))
+                self.assertEqual(
+                    "Login: ingestor\n"
+                    "OrigDatablocks: delete /99001234/myscan_00002\n"
+                    "OrigDatablocks: /99001234/myscan_00002\n",
+                    vl)
+                self.assertEqual(len(self.__server.userslogin), 2)
+                self.assertEqual(
+                    self.__server.userslogin[0],
+                    b'{"username": "ingestor", "password": "12342345"}')
+                self.assertEqual(
+                    self.__server.userslogin[1],
+                    b'{"username": "ingestor", "password": "12342345"}')
+                # self.assertEqual(
+                #     self.__server.userslogin[2],
+                #     b'{"username": "ingestor", "password": "12342345"}')
+                self.assertEqual(len(self.__server.datasets), 2)
+                self.myAssertDict(
+                    json.loads(self.__server.datasets[0]),
+                    {'contactEmail': 'appuser@fake.com',
+                     'createdAt': '2022-05-14 11:54:29',
+                     'creationLocation': '/DESY/PETRA III/P00',
+                     'instrumentId': '/petra3/p00',
+                     'description': 'H20 distribution',
+                     'creationTime': '2022-05-19 09:00:00',
+                     'endTime': '2022-05-19 09:00:00',
+                     'isPublished': False,
+                     'techniques': [],
+                     'owner': 'Smithson',
+                     'ownerGroup': '99001234-dmgt',
+                     'ownerEmail': 'peter.smithson@fake.de',
+                     'pid': '99001234/myscan_00001',
+                     'datasetName': 'myscan_00001',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'principalInvestigator': 'appuser@fake.com',
+                     'proposalId': '99001234',
+                     'scientificMetadata': {
+                         'DOOR_proposalId': '99991173',
+                         'beamtimeId': '99001234'},
+                     'sourceFolder':
+                     '/asap3/petra3/gpfs/p00/2022/data/9901234/raw/special',
+                     'type': 'raw',
+                     'updatedAt': '2022-05-14 11:54:29'},
+                    skip=['creationTime'])
+                self.myAssertDict(
+                    json.loads(self.__server.datasets[1]),
+                    {'contactEmail': 'appuser@fake.com',
+                     'createdAt': '2022-05-14 11:54:29',
+                     'instrumentId': '/petra3/p00',
+                     'creationLocation': '/DESY/PETRA III/P00',
+                     'description': 'H20 distribution',
+                     'creationTime': '2022-05-19 09:00:00',
+                     'endTime': '2022-05-19 09:00:00',
+                     'isPublished': False,
+                     'techniques': [],
+                     'owner': 'Smithson',
+                     'ownerEmail': 'peter.smithson@fake.de',
+                     'ownerGroup': '99001234-dmgt',
+                     'pid': '99001234/myscan_00002',
+                     'datasetName': 'myscan_00002',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'principalInvestigator': 'appuser@fake.com',
+                     'proposalId': '99001234',
+                     'scientificMetadata': {
+                         'DOOR_proposalId': '99991173',
+                         'beamtimeId': '99001234'},
+                     'sourceFolder':
+                     '/asap3/petra3/gpfs/p00/2022/data/9901234/raw/special',
+                     'type': 'raw',
+                     'updatedAt': '2022-05-14 11:54:29'},
+                    skip=['creationTime'])
+                self.assertEqual(len(self.__server.origdatablocks), 3)
+                self.myAssertDict(
+                    json.loads(self.__server.origdatablocks[0]),
+                    {'dataFileList': [
+                        {'gid': 'jkotan',
+                         'path': 'myscan_00001.scan.json',
+                         'perm': '-rw-r--r--',
+                         'size': 629,
+                         'time': '2022-07-05T19:07:16.683673+0200',
+                         'uid': 'jkotan'}],
+                     'datasetId': '/99001234/myscan_00001',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'ownerGroup': '99001234-dmgt',
+                     'size': 629}, skip=["dataFileList", "size"])
+                self.myAssertDict(
+                    json.loads(self.__server.origdatablocks[1]),
+                    {'dataFileList': [
+                        {'gid': 'jkotan',
+                         'path': 'myscan_00001.scan.json',
+                         'perm': '-rw-r--r--',
+                         'size': 629,
+                         'time': '2022-07-05T19:07:16.683673+0200',
+                         'uid': 'jkotan'}],
+                     'datasetId': '/99001234/myscan_00002',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'ownerGroup': '99001234-dmgt',
+                     'size': 629}, skip=["dataFileList", "size"])
+                self.myAssertDict(
+                    json.loads(self.__server.origdatablocks[2]),
+                    {'dataFileList': [
+                        {'gid': 'jkotan',
+                         'path': 'myscan_00001.scan.json',
+                         'perm': '-rw-r--r--',
+                         'size': 629,
+                         'time': '2022-07-05T19:07:16.683673+0200',
+                         'uid': 'jkotan'}],
+                     'datasetId': '/99001234/myscan_00002',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'ownerGroup': '99001234-dmgt',
+                     'size': 629}, skip=["dataFileList", "size"])
+                if os.path.isdir(fsubdirname):
+                    shutil.rmtree(fsubdirname)
+        finally:
+            if os.path.exists(cfgfname):
+                os.remove(cfgfname)
+            if os.path.isdir(fdirname):
+                shutil.rmtree(fdirname)
+
+    def test_datasetfile_jsonchange_mixed_post2_server_error(self):
+        fun = sys._getframe().f_code.co_name
+        # print("Run: %s.%s() " % (self.__class__.__name__, fun))
+        dirname = "test_current"
+        while os.path.exists(dirname):
+            dirname = dirname + '_1'
+        fdirname = os.path.abspath(dirname)
+        fsubdirname = os.path.abspath(os.path.join(dirname, "raw"))
+        fsubdirname2 = os.path.abspath(os.path.join(fsubdirname, "special"))
+        btmeta = "beamtime-metadata-99001234.json"
+        dslist = "scicat-datasets-99001234.lst"
+        idslist = "scicat-ingested-datasets-99001234.lst"
+        wrongdslist = "scicat-datasets-99001235.lst"
+        source = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                              "config",
+                              btmeta)
+        lsource = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                               "config",
+                               dslist)
+        wlsource = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                                "config",
+                                wrongdslist)
+        # fullbtmeta = os.path.join(fdirname, btmeta)
+        fdslist = os.path.join(fsubdirname2, dslist)
+        fidslist = os.path.join(fsubdirname2, idslist)
+        credfile = os.path.join(fdirname, 'pwd')
+        url = 'http://localhost:8881'
+        vardir = "/"
+        cred = "12342345"
+        os.mkdir(fdirname)
+        with open(credfile, "w") as cf:
+            cf.write(cred)
+
+        cfg = 'beamtime_dirs:\n' \
+            '  - "{basedir}"\n' \
+            'scicat_url: "{url}"\n' \
+            'log_generator_commands: true\n' \
+            'dataset_update_strategy: "mixed"\n' \
+            'ingestor_var_dir: "{vardir}"\n' \
+            'ingestor_credential_file: "{credfile}"\n'.format(
+                basedir=fdirname, url=url, vardir=vardir, credfile=credfile)
+
+        cfgfname = "%s_%s.yaml" % (self.__class__.__name__, fun)
+        with open(cfgfname, "w+") as cf:
+            cf.write(cfg)
+        commands = [('scicat_dataset_ingest -c %s'
+                     % cfgfname).split(),
+                    ('scicat_dataset_ingest --config %s'
+                     % cfgfname).split()]
+        # commands.pop()
+        try:
+            for cmd in commands:
+                os.mkdir(fsubdirname)
+                os.mkdir(fsubdirname2)
+                shutil.copy(source, fdirname)
+                shutil.copy(lsource, fsubdirname2)
+                shutil.copy(wlsource, fsubdirname)
+                self.__server.reset()
+                self.__server.error_requests = [14]
+                if os.path.exists(fidslist):
+                    os.remove(fidslist)
+
+                vl, er = self.runtest(cmd)
+
+                scfname = "%s/%s.scan.json" % (fsubdirname2, 'myscan_00001')
+                odbfname = "%s/%s.origdatablock.json" \
+                    % (fsubdirname2, 'myscan_00002')
+
+                scdict = {}
+                with open(scfname, "r") as fl:
+                    scn = fl.read()
+                    scdict = json.loads(scn)
+                scdict["owner"] = "NewOwner"
+                scdict["contactEmail"] = "new.owner@ggg.gg"
+                scdict["techniques"] = [
+                   {
+                       'name': 'small angle x-ray scattering',
+                       'pid':
+                       'http://purl.org/pan-science/PaNET/PaNET01188'
+                   }
+                ]
+                with open(scfname, "w") as fl:
+                    fl.write(json.dumps(scdict))
+
+                scdict = {}
+                with open(odbfname, "r") as fl:
+                    scn = fl.read()
+                    scdict = json.loads(scn)
+                scdict["size"] = 123123
+                with open(odbfname, "w") as fl:
+                    fl.write(json.dumps(scdict))
+
+                vl, er = self.runtest(cmd)
+
+                ser = er.split("\n")
+                seri = [ln for ln in ser if not ln.startswith("127.0.0.1")]
+                # print(er)
+                # sero = [ln for ln in ser if ln.startswith("127.0.0.1")]
+                self.assertEqual(
+                    'INFO : DatasetIngest: beamtime path: {basedir}\n'
+                    'INFO : DatasetIngest: beamtime file: '
+                    'beamtime-metadata-99001234.json\n'
+                    'INFO : DatasetIngest: dataset list: {dslist}\n'
+                    'INFO : DatasetIngestor: Checking: {dslist} {sc1}\n'
+                    'INFO : DatasetIngestor: Checking origdatablock metadata:'
+                    ' {sc1} {subdir2}/{sc1}.origdatablock.json\n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock command: '
+                    'nxsfileinfo origdatablock  '
+                    '-s *.pyc,*.origdatablock.json,*.scan.json,'
+                    '*.attachment.json,*~  '
+                    '-w 99001234-dmgt '
+                    '-c 99001234-dmgt,99001234-clbt,99001234-part,'
+                    'p00dmgt,p00staff '
+                    '-p /99001234/myscan_00001  '
+                    '{subdir2}/{sc1} \n'
+                    'INFO : DatasetIngestor: Check if dataset exists: '
+                    '/99001234/{sc1}\n'
+                    'INFO : DatasetIngestor: Find the dataset by id: '
+                    '/99001234/{sc1}\n'
+                    'INFO : DatasetIngestor: '
+                    'Post the dataset with a new pid: /99001234/{sc1}/2\n'
+                    'ERROR : DatasetIngestor: '
+                    '{{"Error": "Internal Error"}}\n'
+                    'INFO : DatasetIngestor: Ingest dataset: '
+                    '{subdir2}/{sc1}.scan.json\n'
+                    'INFO : DatasetIngestor: Checking: {dslist} {sc2}\n'
+                    'INFO : DatasetIngestor: Checking origdatablock metadata:'
+                    ' {sc2} {subdir2}/{sc2}.origdatablock.json\n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock command: '
+                    'nxsfileinfo origdatablock  '
+                    '-s *.pyc,*.origdatablock.json,*.scan.json,'
+                    '*.attachment.json,*~  '
+                    '-w 99001234-dmgt '
+                    '-c 99001234-dmgt,99001234-clbt,99001234-part,'
+                    'p00dmgt,p00staff '
+                    '-p /99001234/myscan_00002  '
+                    '{subdir2}/{sc2} \n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock metadata:'
+                    ' {sc2} {subdir2}/{sc2}.origdatablock.json\n'
+                    'INFO : DatasetIngestor: Ingest origdatablock:'
+                    ' {subdir2}/{sc2}.origdatablock.json\n'
+                    .format(basedir=fdirname,
+                            subdir2=fsubdirname2,
+                            dslist=fdslist,
+                            sc1='myscan_00001', sc2='myscan_00002'),
+                    "\n".join(seri))
+                self.assertEqual(
+                    "Login: ingestor\n"
+                    "OrigDatablocks: delete /99001234/myscan_00002\n"
+                    "OrigDatablocks: /99001234/myscan_00002\n",
+                    vl)
+                self.assertEqual(len(self.__server.userslogin), 2)
+                self.assertEqual(
+                    self.__server.userslogin[0],
+                    b'{"username": "ingestor", "password": "12342345"}')
+                self.assertEqual(
+                    self.__server.userslogin[1],
+                    b'{"username": "ingestor", "password": "12342345"}')
+                # self.assertEqual(
+                #     self.__server.userslogin[2],
+                #     b'{"username": "ingestor", "password": "12342345"}')
+                self.assertEqual(len(self.__server.datasets), 2)
+                self.myAssertDict(
+                    json.loads(self.__server.datasets[0]),
+                    {'contactEmail': 'appuser@fake.com',
+                     'createdAt': '2022-05-14 11:54:29',
+                     'creationLocation': '/DESY/PETRA III/P00',
+                     'instrumentId': '/petra3/p00',
+                     'description': 'H20 distribution',
+                     'creationTime': '2022-05-19 09:00:00',
+                     'endTime': '2022-05-19 09:00:00',
+                     'isPublished': False,
+                     'techniques': [],
+                     'owner': 'Smithson',
+                     'ownerGroup': '99001234-dmgt',
+                     'ownerEmail': 'peter.smithson@fake.de',
+                     'pid': '99001234/myscan_00001',
+                     'datasetName': 'myscan_00001',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'principalInvestigator': 'appuser@fake.com',
+                     'proposalId': '99001234',
+                     'scientificMetadata': {
+                         'DOOR_proposalId': '99991173',
+                         'beamtimeId': '99001234'},
+                     'sourceFolder':
+                     '/asap3/petra3/gpfs/p00/2022/data/9901234/raw/special',
+                     'type': 'raw',
+                     'updatedAt': '2022-05-14 11:54:29'},
+                    skip=['creationTime'])
+                self.myAssertDict(
+                    json.loads(self.__server.datasets[1]),
+                    {'contactEmail': 'appuser@fake.com',
+                     'createdAt': '2022-05-14 11:54:29',
+                     'instrumentId': '/petra3/p00',
+                     'creationLocation': '/DESY/PETRA III/P00',
+                     'description': 'H20 distribution',
+                     'creationTime': '2022-05-19 09:00:00',
+                     'endTime': '2022-05-19 09:00:00',
+                     'isPublished': False,
+                     'techniques': [],
+                     'owner': 'Smithson',
+                     'ownerEmail': 'peter.smithson@fake.de',
+                     'ownerGroup': '99001234-dmgt',
+                     'pid': '99001234/myscan_00002',
+                     'datasetName': 'myscan_00002',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'principalInvestigator': 'appuser@fake.com',
+                     'proposalId': '99001234',
+                     'scientificMetadata': {
+                         'DOOR_proposalId': '99991173',
+                         'beamtimeId': '99001234'},
+                     'sourceFolder':
+                     '/asap3/petra3/gpfs/p00/2022/data/9901234/raw/special',
+                     'type': 'raw',
+                     'updatedAt': '2022-05-14 11:54:29'},
+                    skip=['creationTime'])
+                self.assertEqual(len(self.__server.origdatablocks), 3)
+                self.myAssertDict(
+                    json.loads(self.__server.origdatablocks[0]),
+                    {'dataFileList': [
+                        {'gid': 'jkotan',
+                         'path': 'myscan_00001.scan.json',
+                         'perm': '-rw-r--r--',
+                         'size': 629,
+                         'time': '2022-07-05T19:07:16.683673+0200',
+                         'uid': 'jkotan'}],
+                     'datasetId': '/99001234/myscan_00001',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'ownerGroup': '99001234-dmgt',
+                     'size': 629}, skip=["dataFileList", "size"])
+                self.myAssertDict(
+                    json.loads(self.__server.origdatablocks[1]),
+                    {'dataFileList': [
+                        {'gid': 'jkotan',
+                         'path': 'myscan_00001.scan.json',
+                         'perm': '-rw-r--r--',
+                         'size': 629,
+                         'time': '2022-07-05T19:07:16.683673+0200',
+                         'uid': 'jkotan'}],
+                     'datasetId': '/99001234/myscan_00002',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'ownerGroup': '99001234-dmgt',
+                     'size': 629}, skip=["dataFileList", "size"])
+                self.myAssertDict(
+                    json.loads(self.__server.origdatablocks[2]),
                     {'dataFileList': [
                         {'gid': 'jkotan',
                          'path': 'myscan_00001.scan.json',

--- a/test/DatasetIngest_test.py
+++ b/test/DatasetIngest_test.py
@@ -1020,6 +1020,236 @@ optional arguments:
             if os.path.isdir(fdirname):
                 shutil.rmtree(fdirname)
 
+    def test_datasetfile_exist_attachment_pid_error(self):
+        fun = sys._getframe().f_code.co_name
+        # print("Run: %s.%s() " % (self.__class__.__name__, fun))
+        dirname = "test_current"
+        while os.path.exists(dirname):
+            dirname = dirname + '_1'
+        fdirname = os.path.abspath(dirname)
+        fsubdirname = os.path.abspath(os.path.join(dirname, "raw"))
+        fsubdirname2 = os.path.abspath(os.path.join(fsubdirname, "special"))
+        btmeta = "bt-mt-99001234.jsn"
+        dslist = "sc-ds-99001234.lst"
+        idslist = "sc-ids-99001234.lst"
+        wrongdslist = "sc-ds-99001235.lst"
+        jatt = "myscan_00002.attachment.json"
+        source = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                              "config",
+                              btmeta)
+        lsource = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                               "config",
+                               dslist)
+        wlsource = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                                "config",
+                                wrongdslist)
+        asource = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                               "config",
+                               jatt)
+        fullbtmeta = os.path.join(fdirname, btmeta)
+        fdslist = os.path.join(fsubdirname2, dslist)
+        fidslist = os.path.join(fsubdirname2, idslist)
+        credfile = os.path.join(fdirname, 'pwd')
+        url = 'http://localhost:8881'
+        vardir = "/"
+        cred = "12342345"
+        os.mkdir(fdirname)
+        with open(credfile, "w") as cf:
+            cf.write(cred)
+
+        cfg = 'beamtime_dirs:\n' \
+            '  - "{basedir}"\n' \
+            'beamtime_filename_prefix: "bt-mt-"\n' \
+            'beamtime_filename_postfix: ".jsn"\n' \
+            'datasets_filename_pattern: "sc-ds-{{beamtimeid}}.lst"\n' \
+            'ingest_dataset_attachment: true\n' \
+            'ingested_datasets_filename_pattern: ' \
+            '"sc-ids-{{beamtimeid}}.lst"\n' \
+            'log_generator_commands: true\n' \
+            'inotify_timeout: 0.2\n' \
+            'get_event_timeout: 0.02\n' \
+            'ingestion_delay_time: 2\n' \
+            'max_request_tries_number: 10\n' \
+            'recheck_beamtime_file_interval: 1000\n' \
+            'recheck_dataset_list_interval: 1000\n' \
+            'scicat_url: "{url}"\n' \
+            'ingestor_var_dir: "{vardir}"\n' \
+            'ingestor_credential_file: "{credfile}"\n'.format(
+                basedir=fdirname, url=url, vardir=vardir, credfile=credfile)
+
+        cfgfname = "%s_%s.yaml" % (self.__class__.__name__, fun)
+        with open(cfgfname, "w+") as cf:
+            cf.write(cfg)
+        commands = [("scicat_dataset_ingest  -c %s"
+                     % cfgfname).split(),
+                    ("scicat_dataset_ingest --config %s"
+                     % cfgfname).split()]
+        # commands.pop()
+        try:
+            for cmd in commands:
+                os.mkdir(fsubdirname)
+                os.mkdir(fsubdirname2)
+                shutil.copy(source, fdirname)
+                shutil.copy(lsource, fsubdirname2)
+                shutil.copy(wlsource, fsubdirname)
+                shutil.copy(asource, fsubdirname2)
+
+                self.__server.reset()
+                self.__server.error_requests = [7]
+                if os.path.exists(fidslist):
+                    os.remove(fidslist)
+                vl, er = self.runtest(cmd)
+                ser = er.split("\n")
+                seri = [ln for ln in ser if not ln.startswith("127.0.0.1")]
+                # print(vl)
+                # print(er)
+                # sero = [ln for ln in ser if ln.startswith("127.0.0.1")]
+                self.assertEqual(
+                    'INFO : DatasetIngest: beamtime path: {basedir}\n'
+                    'INFO : DatasetIngest: beamtime file: '
+                    'bt-mt-99001234.jsn\n'
+                    'INFO : DatasetIngest: dataset list: {dslist}\n'
+                    'INFO : DatasetIngestor: Checking: {dslist} {sc1}\n'
+                    'INFO : DatasetIngestor: Generating metadata: '
+                    '{sc1} {subdir2}/{sc1}.scan.json\n'
+                    'INFO : DatasetIngestor: Generating dataset command: '
+                    'nxsfileinfo metadata  -o {subdir2}/{sc1}.scan.json  '
+                    '-c 99001234-dmgt,99001234-clbt,99001234-part,'
+                    'p00dmgt,p00staff -w 99001234-dmgt '
+                    '-b {btmeta} '
+                    '-p 99001234/myscan_00001'
+                    ' -r raw/special  --add-empty-units \n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock metadata:'
+                    ' {sc1} {subdir2}/{sc1}.origdatablock.json\n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock command: '
+                    'nxsfileinfo origdatablock  '
+                    '-s *.pyc,*.origdatablock.json,*.scan.json,'
+                    '*.attachment.json,*~  '
+                    '-p /99001234/myscan_00001  -w 99001234-dmgt '
+                    '-c 99001234-dmgt,99001234-clbt,99001234-part,'
+                    'p00dmgt,p00staff '
+                    '-o {subdir2}/{sc1}.origdatablock.json  '
+                    '{subdir2}/{sc1} \n'
+                    'INFO : DatasetIngestor: Check if dataset exists: '
+                    '/99001234/{sc1}\n'
+                    'INFO : DatasetIngestor: Post the dataset: '
+                    '/99001234/{sc1}\n'
+                    'INFO : DatasetIngestor: Ingest dataset: '
+                    '{subdir2}/{sc1}.scan.json\n'
+                    'INFO : DatasetIngestor: Ingest origdatablock: '
+                    '{subdir2}/{sc1}.origdatablock.json\n'
+                    'INFO : DatasetIngestor: Checking: {dslist} {sc2}\n'
+                    'INFO : DatasetIngestor: Generating metadata: '
+                    '{sc2} {subdir2}/{sc2}.scan.json\n'
+                    'INFO : DatasetIngestor: Generating dataset command: '
+                    'nxsfileinfo metadata  -o {subdir2}/{sc2}.scan.json  '
+                    '-c 99001234-dmgt,99001234-clbt,99001234-part,'
+                    'p00dmgt,p00staff -w 99001234-dmgt '
+                    '-b {btmeta} '
+                    '-p 99001234/myscan_00002'
+                    ' -r raw/special  --add-empty-units \n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock metadata:'
+                    ' {sc2} {subdir2}/{sc2}.origdatablock.json\n'
+                    'INFO : DatasetIngestor: '
+                    'Generating origdatablock command: '
+                    'nxsfileinfo origdatablock  '
+                    '-s *.pyc,*.origdatablock.json,*.scan.json,'
+                    '*.attachment.json,*~  '
+                    '-p /99001234/myscan_00002  -w 99001234-dmgt '
+                    '-c 99001234-dmgt,99001234-clbt,99001234-part,'
+                    'p00dmgt,p00staff '
+                    '-o {subdir2}/{sc2}.origdatablock.json  '
+                    '{subdir2}/{sc2} \n'
+                    'INFO : DatasetIngestor: Check if dataset exists: '
+                    '/99001234/{sc2}\n'
+                    'INFO : DatasetIngestor: Post the dataset: '
+                    '/99001234/{sc2}\n'
+                    'ERROR : DatasetIngestor: '
+                    '{{"Error": "Internal Error"}}\n'
+                    'INFO : DatasetIngestor: Ingest dataset: '
+                    '{subdir2}/{sc2}.scan.json\n'
+                    'ERROR : DatasetIngestor: '
+                    'Wrong origdatablock datasetId None for DESY '
+                    'beamtimeId 99001234 in  '
+                    '{subdir2}/{sc2}.origdatablock.json\n'
+                    'INFO : DatasetIngestor: Ingest origdatablock: '
+                    '{subdir2}/{sc2}.origdatablock.json\n'
+                    'ERROR : DatasetIngestor: \'pid\'\n'
+                    'ERROR : DatasetIngestor: No dataset '
+                    'pid for the attachment found: '
+                    '{subdir2}/{sc2}.attachment.json\n'
+                    .format(basedir=fdirname,
+                            subdir2=fsubdirname2,
+                            dslist=fdslist,
+                            btmeta=fullbtmeta,
+                            sc1='myscan_00001', sc2='myscan_00002'),
+                    "\n".join(seri))
+                self.assertEqual(
+                    "Login: ingestor\n"
+                    "RawDatasets: 99001234/myscan_00001\n"
+                    "OrigDatablocks: /99001234/myscan_00001\n", vl)
+                self.assertEqual(len(self.__server.userslogin), 1)
+                self.assertEqual(
+                    self.__server.userslogin[0],
+                    b'{"username": "ingestor", "password": "12342345"}')
+                self.assertEqual(len(self.__server.datasets), 1)
+                self.myAssertDict(
+                    json.loads(self.__server.datasets[0]),
+                    {'contactEmail': 'appuser@fake.com',
+                     'createdAt': '2022-05-14 11:54:29',
+                     'creationLocation': '/DESY/PETRA III/P00',
+                     'instrumentId': '/petra3/p00',
+                     'description': 'H20 distribution',
+                     'creationTime': '2022-05-19 09:00:00',
+                     'endTime': '2022-05-19 09:00:00',
+                     'isPublished': False,
+                     'techniques': [],
+                     'owner': 'Smithson',
+                     'ownerGroup': '99001234-dmgt',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'ownerEmail': 'peter.smithson@fake.de',
+                     'pid': '99001234/myscan_00001',
+                     'datasetName': 'myscan_00001',
+                     'principalInvestigator': 'appuser@fake.com',
+                     'proposalId': '99001234',
+                     'scientificMetadata': {
+                         'DOOR_proposalId': '99991173',
+                         'beamtimeId': '99001234'},
+                     'sourceFolder':
+                     '/asap3/petra3/gpfs/p00/2022/data/9901234/raw/special',
+                     'type': 'raw',
+                     'updatedAt': '2022-05-14 11:54:29'},
+                    skip=['creationTime'])
+                self.assertEqual(len(self.__server.origdatablocks), 1)
+                self.myAssertDict(
+                    json.loads(self.__server.origdatablocks[0]),
+                    {'dataFileList': [
+                        {'gid': 'jkotan',
+                         'path': 'myscan_00001.scan.json',
+                         'perm': '-rw-r--r--',
+                         'size': 629,
+                         'time': '2022-07-05T19:07:16.683673+0200',
+                         'uid': 'jkotan'}],
+                     'ownerGroup': '99001234-dmgt',
+                     'accessGroups': [
+                         '99001234-dmgt', '99001234-clbt', '99001234-part',
+                         'p00dmgt', 'p00staff'],
+                     'datasetId': '/99001234/myscan_00001',
+                     'size': 629}, skip=["dataFileList", "size"])
+                self.assertEqual(len(self.__server.attachments), 0)
+                if os.path.isdir(fsubdirname):
+                    shutil.rmtree(fsubdirname)
+        finally:
+            if os.path.exists(cfgfname):
+                os.remove(cfgfname)
+            if os.path.isdir(fdirname):
+                shutil.rmtree(fdirname)
+
     def test_datasetfile_exist_attachment_server_error(self):
         fun = sys._getframe().f_code.co_name
         # print("Run: %s.%s() " % (self.__class__.__name__, fun))

--- a/test/ModelIngest_test.py
+++ b/test/ModelIngest_test.py
@@ -575,11 +575,11 @@ optional arguments:
                 self.assertEqual(
                     'ERROR : ModelIngestor: {"Error": "Empty username"}\n'
                     "INFO : ModelIngestor: Post the RawDatasets from "
-                    "ModelIngestTest_test_modelfile_wrong_user_00001."
+                    "ModelIngestTest_test_modelfile_wrong_username_00001."
                     "dataset.json\n"
                     'ERROR : ModelIngestor: {"Error": "Empty access_token"}\n'
                     "INFO : ModelIngestor: Post the RawDatasets from "
-                    "ModelIngestTest_test_modelfile_wrong_user_00002."
+                    "ModelIngestTest_test_modelfile_wrong_username_00002."
                     "dataset.json\n"
                     'ERROR : ModelIngestor: {"Error": "Empty access_token"}\n',
                     "\n".join(seri))

--- a/test/ModelIngest_test.py
+++ b/test/ModelIngest_test.py
@@ -467,6 +467,140 @@ optional arguments:
             if os.path.isdir(fdirname):
                 shutil.rmtree(fdirname)
 
+    def test_modelfile_wrong_username(self):
+        fun = sys._getframe().f_code.co_name
+        # print("Run: %s.%s() " % (self.__class__.__name__, fun))
+        dirname = "test_current"
+        while os.path.exists(dirname):
+            dirname = dirname + '_1'
+        fdirname = os.path.abspath(dirname)
+        # fullbtmeta = os.path.join(fdirname, btmeta)
+        credfile = os.path.join(fdirname, 'pwd')
+        url = 'http://localhost:8881'
+        cred = "12342345"
+        os.mkdir(fdirname)
+        with open(credfile, "w") as cf:
+            cf.write(cred)
+
+        cfg = 'scicat_url: "{url}"\n' \
+            'ingestor_username: ""\n' \
+            'max_request_tries_number: 10\n' \
+            'request_headers:\n' \
+            '  "Content-Type": "application/json"\n' \
+            '  "Accept": "application/json"\n' \
+            'ingestor_credential_file: "{credfile}"\n'.format(
+                url=url, credfile=credfile)
+
+        jsns = [
+            {'contactEmail': 'appuser@fake.com',
+             'createdAt': '2022-05-14 11:54:29',
+             'instrumentId': '/petra3/p00',
+             'creationLocation': '/DESY/PETRA III/P00',
+             'description': 'H20 distribution',
+             'endTime': '2022-05-19 09:00:00',
+             'isPublished': False,
+             'techniques': [],
+             'owner': 'Smithson',
+             'ownerGroup': '99001234-dmgt',
+             'ownerEmail': 'peter.smithson@fake.de',
+             'pid': '99001234/myscan_00001',
+             'datasetName': 'myscan_00001',
+             'accessGroups': [
+                 '99001234-dmgt', '99001234-clbt', '99001234-part',
+                 'p00dmgt', 'p00staff'],
+             'principalInvestigator': 'appuser@fake.com',
+             'proposalId': '99001234',
+             'scientificMetadata': {
+                 'DOOR_proposalId': '99991173',
+                 'beamtimeId': '99001234'},
+             'sourceFolder':
+             '/asap3/petra3/gpfs/p00/2022/data/9901234/raw/special',
+             'type': 'raw',
+             'updatedAt': '2022-05-14 11:54:29'},
+
+            {'contactEmail': 'appuser@fake.com',
+             'createdAt': '2022-05-14 11:54:29',
+             'instrumentId': '/petra3/p00',
+             'creationLocation': '/DESY/PETRA III/P00',
+             'description': 'H20 distribution',
+             'endTime': '2022-05-19 09:00:00',
+             'isPublished': False,
+             'techniques': [],
+             'owner': 'Smithson',
+             'ownerEmail': 'peter.smithson@fake.de',
+             'ownerGroup': '99001234-dmgt',
+             'pid': '99001234/myscan_00002',
+             'datasetName': 'myscan_00002',
+             'principalInvestigator': 'appuser@fake.com',
+             'accessGroups': [
+                 '99001234-dmgt', '99001234-clbt', '99001234-part',
+                 'p00dmgt', 'p00staff'],
+             'proposalId': '99001234',
+             'scientificMetadata': {
+                 'DOOR_proposalId': '99991173',
+                 'beamtimeId': '99001234'},
+             'sourceFolder':
+             '/asap3/petra3/gpfs/p00/2022/data/9901234/raw/special',
+             'type': 'raw',
+             'updatedAt': '2022-05-14 11:54:29'}
+        ]
+
+        jsnfiles = [
+            "%s_%s_00001.dataset.json" % (self.__class__.__name__, fun),
+            "%s_%s_00002.dataset.json" % (self.__class__.__name__, fun)
+        ]
+        for k, jfile in enumerate(jsnfiles):
+            with open(jfile, "w+") as jf:
+                jf.write(json.dumps(jsns[k]))
+
+        cfgfname = "%s_%s.yaml" % (self.__class__.__name__, fun)
+        with open(cfgfname, "w+") as cf:
+            cf.write(cfg)
+        commands = [("scicat_ingest -m RawDatasets -c %s  "
+                     % (cfgfname)).split(),
+                    ("scicat_ingest --model RawDatasets --config %s "
+                     % (cfgfname)).split()]
+        # commands.pop()
+        try:
+            for cmd in commands:
+                self.__server.reset()
+                cmd.extend(jsnfiles)
+                # print(cmd)
+                vl, er = self.runtest(cmd)
+                ser = er.split("\n")
+                seri = [ln for ln in ser if not ln.startswith("127.0.0.1")]
+                # print(vl)
+                # print(er)
+                # sero = [ln for ln in ser if ln.startswith("127.0.0.1")]
+                self.assertEqual(
+                    'ERROR : ModelIngestor: {"Error": "Empty username"}\n'
+                    "INFO : ModelIngestor: Post the RawDatasets from "
+                    "ModelIngestTest_test_modelfile_wrong_user_00001."
+                    "dataset.json\n"
+                    'ERROR : ModelIngestor: {"Error": "Empty access_token"}\n'
+                    "INFO : ModelIngestor: Post the RawDatasets from "
+                    "ModelIngestTest_test_modelfile_wrong_user_00002."
+                    "dataset.json\n"
+                    'ERROR : ModelIngestor: {"Error": "Empty access_token"}\n',
+                    "\n".join(seri))
+                self.assertEqual(
+                    "Login: \n", vl)
+                self.assertEqual(len(self.__server.userslogin), 1)
+                self.assertEqual(
+                    self.__server.userslogin[0],
+                    b'{"username": "", "password": "12342345"}')
+                self.assertEqual(len(self.__server.datasets), 0)
+                self.assertEqual(len(self.__server.origdatablocks), 0)
+        finally:
+            if os.path.exists(cfgfname):
+                os.remove(cfgfname)
+            if os.path.exists(jsnfiles[0]):
+                os.remove(jsnfiles[0])
+            if os.path.exists(jsnfiles[1]):
+                os.remove(jsnfiles[1])
+            if os.path.isdir(fdirname):
+                shutil.rmtree(fdirname)
+
     def test_modelfile_wrong_format(self):
         fun = sys._getframe().f_code.co_name
         # print("Run: %s.%s() " % (self.__class__.__name__, fun))
@@ -530,81 +664,6 @@ optional arguments:
                 self.assertEqual(
                     self.__server.userslogin[0],
                     b'{"username": "lingestor", "password": "12342345"}')
-                self.assertEqual(len(self.__server.datasets), 0)
-                self.assertEqual(len(self.__server.origdatablocks), 0)
-        finally:
-            if os.path.exists(cfgfname):
-                os.remove(cfgfname)
-            if os.path.exists(jsnfiles[0]):
-                os.remove(jsnfiles[0])
-            if os.path.exists(jsnfiles[1]):
-                os.remove(jsnfiles[1])
-            if os.path.isdir(fdirname):
-                shutil.rmtree(fdirname)
-
-    def test_modelfile_wrong_username(self):
-        fun = sys._getframe().f_code.co_name
-        # print("Run: %s.%s() " % (self.__class__.__name__, fun))
-        dirname = "test_current"
-        while os.path.exists(dirname):
-            dirname = dirname + '_1'
-        fdirname = os.path.abspath(dirname)
-        # fullbtmeta = os.path.join(fdirname, btmeta)
-        credfile = os.path.join(fdirname, 'pwd')
-        url = 'http://localhost:8881'
-        cred = "12342345"
-        os.mkdir(fdirname)
-        with open(credfile, "w") as cf:
-            cf.write(cred)
-
-        cfg = 'scicat_url: "{url}"\n' \
-            'ingestor_username: ""\n' \
-            'max_request_tries_number: 10\n' \
-            'request_headers:\n' \
-            '  "Content-Type": "application/json"\n' \
-            '  "Accept": "application/json"\n' \
-            'ingestor_credential_file: "{credfile}"\n'.format(
-                url=url, credfile=credfile)
-
-        jsnfiles = [
-            "%s_%s_00001.dataset.json" % (self.__class__.__name__, fun),
-            "%s_%s_00002.dataset.json" % (self.__class__.__name__, fun)
-        ]
-        cfgfname = "%s_%s.yaml" % (self.__class__.__name__, fun)
-        with open(cfgfname, "w+") as cf:
-            cf.write(cfg)
-        commands = [("scicat_ingest -m RawDatasets -c %s  "
-                     % (cfgfname)).split(),
-                    ("scicat_ingest --model RawDatasets --config %s "
-                     % (cfgfname)).split()]
-        # commands.pop()
-        try:
-            for cmd in commands:
-                self.__server.reset()
-                cmd.extend(jsnfiles)
-                # print(cmd)
-                vl, er = self.runtest(cmd)
-                ser = er.split("\n")
-                seri = [ln for ln in ser if not ln.startswith("127.0.0.1")]
-                # print(vl)
-                # print(er)
-                # sero = [ln for ln in ser if ln.startswith("127.0.0.1")]
-                self.assertEqual(
-                    'ERROR : DatasetIngestor: {"Error": "Empty username"}\n'
-                    "ERROR : ModelIngestor: [Errno 2] "
-                    "No such file or directory: "
-                    "'ModelIngestTest_test_modelfile_wrong_username_"
-                    "00001.dataset.json'\n"
-                    "ERROR : ModelIngestor: [Errno 2] "
-                    "No such file or directory: "
-                    "'ModelIngestTest_test_modelfile_wrong_username_"
-                    "00002.dataset.json'\n",
-                    "\n".join(seri))
-                self.assertEqual("Login: \n", vl)
-                self.assertEqual(len(self.__server.userslogin), 1)
-                self.assertEqual(
-                    self.__server.userslogin[0],
-                    b'{"username": "", "password": "12342345"}')
                 self.assertEqual(len(self.__server.datasets), 0)
                 self.assertEqual(len(self.__server.origdatablocks), 0)
         finally:

--- a/test/ModelIngest_test.py
+++ b/test/ModelIngest_test.py
@@ -542,6 +542,81 @@ optional arguments:
             if os.path.isdir(fdirname):
                 shutil.rmtree(fdirname)
 
+    def test_modelfile_wrong_username(self):
+        fun = sys._getframe().f_code.co_name
+        # print("Run: %s.%s() " % (self.__class__.__name__, fun))
+        dirname = "test_current"
+        while os.path.exists(dirname):
+            dirname = dirname + '_1'
+        fdirname = os.path.abspath(dirname)
+        # fullbtmeta = os.path.join(fdirname, btmeta)
+        credfile = os.path.join(fdirname, 'pwd')
+        url = 'http://localhost:8881'
+        cred = "12342345"
+        os.mkdir(fdirname)
+        with open(credfile, "w") as cf:
+            cf.write(cred)
+
+        cfg = 'scicat_url: "{url}"\n' \
+            'ingestor_username: ""\n' \
+            'max_request_tries_number: 10\n' \
+            'request_headers:\n' \
+            '  "Content-Type": "application/json"\n' \
+            '  "Accept": "application/json"\n' \
+            'ingestor_credential_file: "{credfile}"\n'.format(
+                url=url, credfile=credfile)
+
+        jsnfiles = [
+            "%s_%s_00001.dataset.json" % (self.__class__.__name__, fun),
+            "%s_%s_00002.dataset.json" % (self.__class__.__name__, fun)
+        ]
+        cfgfname = "%s_%s.yaml" % (self.__class__.__name__, fun)
+        with open(cfgfname, "w+") as cf:
+            cf.write(cfg)
+        commands = [("scicat_ingest -m RawDatasets -c %s  "
+                     % (cfgfname)).split(),
+                    ("scicat_ingest --model RawDatasets --config %s "
+                     % (cfgfname)).split()]
+        # commands.pop()
+        try:
+            for cmd in commands:
+                self.__server.reset()
+                cmd.extend(jsnfiles)
+                # print(cmd)
+                vl, er = self.runtest(cmd)
+                ser = er.split("\n")
+                seri = [ln for ln in ser if not ln.startswith("127.0.0.1")]
+                # print(vl)
+                # print(er)
+                # sero = [ln for ln in ser if ln.startswith("127.0.0.1")]
+                self.assertEqual(
+                    'ERROR : DatasetIngestor: {"Error": "Empty username"}\n'
+                    "ERROR : ModelIngestor: [Errno 2] "
+                    "No such file or directory: "
+                    "'ModelIngestTest_test_modelfile_wrong_username_"
+                    "00001.dataset.json'\n"
+                    "ERROR : ModelIngestor: [Errno 2] "
+                    "No such file or directory: "
+                    "'ModelIngestTest_test_modelfile_wrong_username_"
+                    "00002.dataset.json'\n",
+                    "\n".join(seri))
+                self.assertEqual("Login: \n", vl)
+                self.assertEqual(len(self.__server.userslogin), 1)
+                self.assertEqual(
+                    self.__server.userslogin[0],
+                    b'{"username": "", "password": "12342345"}')
+                self.assertEqual(len(self.__server.datasets), 0)
+                self.assertEqual(len(self.__server.origdatablocks), 0)
+        finally:
+            if os.path.exists(cfgfname):
+                os.remove(cfgfname)
+            if os.path.exists(jsnfiles[0]):
+                os.remove(jsnfiles[0])
+            if os.path.exists(jsnfiles[1]):
+                os.remove(jsnfiles[1])
+            if os.path.isdir(fdirname):
+                shutil.rmtree(fdirname)
+
     def test_modelfile_wrong_type(self):
         fun = sys._getframe().f_code.co_name
         # print("Run: %s.%s() " % (self.__class__.__name__, fun))

--- a/test/SciCatTestServer.py
+++ b/test/SciCatTestServer.py
@@ -129,13 +129,13 @@ class SciCatMockHandler(BaseHTTPRequestHandler):
         elif self.path.lower().startswith(
                 '/rawdatasets?access_token=') and \
                 contenttype == 'application/json':
-            self.server.datasets.append(in_data)
             # print(in_data)
             # print(type(in_data))
             spath = self.path.lower().split("?access_token=")
             try:
                 if not spath[-1]:
                     raise Exception("Empty access_token")
+                self.server.datasets.append(in_data)
                 dt = json.loads(in_data)
                 # print("Datasets: %s" % dt)
                 print("RawDatasets: %s" % dt["pid"])

--- a/test/SciCatTestServer.py
+++ b/test/SciCatTestServer.py
@@ -92,7 +92,6 @@ class SciCatMockHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         """ implementation of action for http POST requests
         """
-        self.set_json_header()
 
         # print(self.headers)
         # print(self.path)

--- a/test/SciCatTestServer.py
+++ b/test/SciCatTestServer.py
@@ -170,30 +170,34 @@ class SciCatMockHandler(BaseHTTPRequestHandler):
                 contenttype == 'application/json':
             spath = self.path.lower().split("?access_token=")
             resp = 200
-            if not spath[-1]:
-                raise Exception("Empty access_token")
-            if len(spath) == 2:
-                lpath = spath[0].split("/")
-                if len(lpath) == 4 and lpath[3] == "attachments":
-                    pid = lpath[2]
-                    pid = pid.replace("%2f", "/")
-                    print("Datasets Attachments: %s" % pid)
-                    self.server.attachments.append((pid, in_data))
-                    try:
-                        dt = json.loads(in_data)
-                        message = "{}"
-                    except Exception as e:
-                        message = json.dumps({"Error": str(e)})
-                        resp = 400
+            try:
+                if not spath[-1]:
+                    raise Exception("Empty access_token")
+                if len(spath) == 2:
+                    lpath = spath[0].split("/")
+                    if len(lpath) == 4 and lpath[3] == "attachments":
+                        pid = lpath[2]
+                        pid = pid.replace("%2f", "/")
+                        print("Datasets Attachments: %s" % pid)
+                        self.server.attachments.append((pid, in_data))
+                        try:
+                            dt = json.loads(in_data)
+                            message = "{}"
+                        except Exception as e:
+                            message = json.dumps({"Error": str(e)})
+                            resp = 400
+            except Exception as e:
+                message = json.dumps({"Error": str(e)})
+                resp = 400
             self.set_json_header(resp)
         elif self.path.lower().startswith(
                 '/origdatablocks?access_token=') and \
                 contenttype == 'application/json':
             self.server.origdatablocks.append(in_data)
             spath = self.path.lower().split("?access_token=")
-            if not spath[-1]:
-                raise Exception("Empty access_token")
             try:
+                if not spath[-1]:
+                    raise Exception("Empty access_token")
                 dt = json.loads(in_data)
                 print("OrigDatablocks: %s" % dt['datasetId'])
                 npid = str(uuid.uuid4())

--- a/test/SciCatTestServer.py
+++ b/test/SciCatTestServer.py
@@ -56,6 +56,14 @@ class SciCatMockHandler(BaseHTTPRequestHandler):
     def do_PATCH(self):
         """ implementation of action for http PATCH requests
         """
+        self.server.counter += 1
+        if self.server.counter in self.server.error_requests:
+            message = json.dumps({"Error": "Internal Error"})
+            resp = 500
+            self.set_json_header(resp)
+            self.wfile.write(bytes(message, "utf8"))
+            return
+
         length = int(self.headers.get('Content-Length'))
         contenttype = self.headers.get('Content-Type')
         in_data = self.rfile.read(length)
@@ -97,6 +105,14 @@ class SciCatMockHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         """ implementation of action for http POST requests
         """
+
+        self.server.counter += 1
+        if self.server.counter in self.server.error_requests:
+            message = json.dumps({"Error": "Internal Error"})
+            resp = 500
+            self.set_json_header(resp)
+            self.wfile.write(bytes(message, "utf8"))
+            return
 
         # print(self.headers)
         # print(self.path)
@@ -201,6 +217,14 @@ class SciCatMockHandler(BaseHTTPRequestHandler):
         """ implementation of action for http GET requests
         """
 
+        self.server.counter += 1
+        if self.server.counter in self.server.error_requests:
+            message = json.dumps({"Error": "Internal Error"})
+            resp = 500
+            self.set_html_header(resp)
+            self.wfile.write(bytes(message, "utf8"))
+            return
+
         message = "SciCat mock server for tests!"
         path = self.path
         if "?access_token=" in path:
@@ -267,6 +291,14 @@ class SciCatMockHandler(BaseHTTPRequestHandler):
     def do_DELETE(self):
         """ implementation of action for http DELETE requests
         """
+        self.server.counter += 1
+        if self.server.counter in self.server.error_requests:
+            message = json.dumps({"Error": "Internal Error"})
+            resp = 500
+            self.set_html_header(resp)
+            self.wfile.write(bytes(message, "utf8"))
+            return
+
         message = "SciCat mock server for tests!"
         path = self.path
         if "?access_token=" in path:
@@ -333,6 +365,10 @@ class SciCatTestServer(HTTPServer):
         self.pid_proposal = {}
         #: (:obj:`dict`<:obj:`str`, :obj:`str`>) dictionary with datablocks
         self.id_origdatablock = {}
+        #: (:obj:`int`) id counter
+        self.counter = 0
+        #: (:obj:`int`) request ids with error
+        self.error_requests = []
         #: (:obj:`str`) pid prefix
         self.pidprefix = "/"
         # self.pidprefix = "10.3204/"
@@ -346,6 +382,8 @@ class SciCatTestServer(HTTPServer):
         self.pid_dataset = {}
         self.pid_proposal = {}
         self.id_origdatablock = {}
+        self.counter = 0
+        self.error_requests = []
 
     def run(self):
         try:

--- a/test/TODO
+++ b/test/TODO
@@ -55,10 +55,6 @@ Tests for  scingestor/datasetIngestor.py
 
 - in _metadataEqual(...) if isinstance(v, dict)  tests ?
 
-- in get_token(self) request exception test e.g. content without id ??
-
-- in get_token(self) exception test if not response.ok ??
-
 - in append_proposal_groups(self) request exception test e.g. content without exists ??
 
 - in append_proposal_groups(self) exception test if not resget.ok ??
@@ -80,8 +76,6 @@ Tests for  scingestor/datasetIngestor.py
 - in _ingest_dataset(...) exception test if not resds.ok ??
 
 - in _ingest_dataset(...) exception test if not resexists.ok  (second) ??
-
-- in _ingest_dataset(...) exception test if request EXCEPTIONS ?????
 
 - in _ingest_origdatablock(...) exception test if not response.ok ??
 
@@ -158,11 +152,7 @@ Tests for  scingestor/datasetWatcher.py
 Tests for  scingestor/modelIngest.py
 -------------------------------------
 
-- in _ingest_model(self, metadata, token) if not response.ok tests
-
-- in get_token  if not request.ok tests
-
-- in get_token  request exception test e.g. content without id ??
+- in _ingest_model(self, metadata, token) last return  ??
 
 
 Tests for  scingestor/safeINotifier.py
@@ -170,6 +160,7 @@ Tests for  scingestor/safeINotifier.py
 
 - in run  os.close(self.__notifier) exception ????
 
+- in _remove()   inotifyx.rm_watch() raise Exception ?? random
 
 Tests for  scingestor/scanDirWatcher.py
 ---------------------------------------
@@ -206,12 +197,12 @@ scingestor/__init__.py              1      0   100%
 scingestor/beamtimeWatcher.py     358     29    92%   221-222, 263-265, 280, 283, 299-302, 360-361, 453-454, 470-476, 483, 512-514, 516-520
 scingestor/configuration.py        10      0   100%
 scingestor/datasetIngest.py       156      4    97%   271-272, 292-293
-scingestor/datasetIngestor.py     829     79    90%   769-770, 772-780, 795, 804-806, 824, 857, 864-868, 870-872, 896-900, 924, 948-953, 977-981, 997, 1014, 1045, 1076-1079, 1081, 1086-1087, 1099, 1137-1143, 1165-1169, 1196-1200, 1223-1224, 1246-1250, 1266-1267, 1287, 1291, 1320, 1322-1323, 1342, 1375, 1427, 1455, 1460, 1607, 1621, 1627, 1670-1671, 1690
+scingestor/datasetIngestor.py     829     72    91%   769-770, 772-780, 795, 804-806, 824, 857, 864-868, 870-872, 924, 948-953, 977-981, 997, 1014, 1045, 1076-1079, 1081, 1086-1087, 1099, 1137-1139, 1165-1169, 1196-1200, 1223-1224, 1246-1250, 1266-1267, 1287, 1291, 1320, 1322-1323, 1342, 1375, 1427, 1455, 1460, 1607, 1621, 1627, 1670-1671, 1690
 scingestor/datasetWatcher.py      152     31    80%   155-156, 175-176, 192-193, 202, 221-223, 232-234, 237-249, 264-266, 280-282, 286-288
 scingestor/logger.py               36      0   100%
-scingestor/modelIngest.py          98      6    94%   165-166, 181-185
+scingestor/modelIngest.py          98      1    99%   166
 scingestor/pathConverter.py        30      0   100%
-scingestor/safeINotifier.py       102      2    98%   229-230
+scingestor/safeINotifier.py       102      4    96%   157-158, 229-230
 scingestor/scanDirWatcher.py      184     24    87%   197-198, 240-241, 283, 311-318, 329-337, 343-344, 351-357, 359-360
 -------------------------------------------------------------
-TOTAL                            1956    175    91%
+TOTAL                            1956    165    92%

--- a/test/TODO
+++ b/test/TODO
@@ -49,15 +49,18 @@ Tests for  scingestor/datasetIngestor.py
 
 - in _regenerate_origdatablock_metadata()  no obds generated  tests ??
 
+
 - in _metadataEqual(...) if parent tests ?
 
 - in _metadataEqual(...) if k not in dct2.keys()  tests ?
 
 - in _metadataEqual(...) if isinstance(v, dict)  tests ?
 
-- in append_proposal_groups(self) request exception test e.g. content without exists ??
+
+- in append_proposal_groups(self) exception if not pexists ??
 
 - in append_proposal_groups(self) exception test if not resget.ok ??
+
 
 - in post_dataset(...) exception test if spid[-1] not int ??
 
@@ -66,6 +69,7 @@ Tests for  scingestor/datasetIngestor.py
 - in post_dataset(...) exception test if not response.ok ??
 
 - in patch_dataset(...) exception test if not response.ok ??
+
 
 - in _ingest_dataset(...) exception test if not resexists.ok ??
 
@@ -77,32 +81,38 @@ Tests for  scingestor/datasetIngestor.py
 
 - in _ingest_dataset(...) exception test if not resexists.ok  (second) ??
 
+
 - in _ingest_origdatablock(...) exception test if not response.ok ??
 
 - in _ingest_origdatablock(...) exception test if request EXCEPTIONS ?????
+
 
 - in _ingest_attachment(...) exception test if not response.ok ??
 
 - in _ingest_attachment(...) exception test if request EXCEPTIONS ?????
 
+
 - in _get_id_first_origdatablock(...) exception test if request EXCEPTIONS ?????
+
 
 - in _get_delete_origdatablock(...) exception test if not response.ok ??
 
 - in _get_delete_origdatablock(...) exception test if request EXCEPTIONS ?????
 
+
 - in _get_pid(...) exception test if metedata is not loadable or no "pid" in metadata ??
+
 
 - in _ingest_rawdataset_metadata() if mt["proposalId"] != self.__bid error (wrong beamtime)
 
 - in _ingest_rawdataset_metadata() if not mt["pid"].startswith("%s/" % (self.__bid)) (wrong beamtime)
 -  in _ingest_rawdataset_metadata() exception test if metedata is not loadable ??
 
+
 - _delete_origdatablocks() duplicated origdatablocks to delete test ?
 
 - _delete_origdatablocks() exception test if request EXCEPTIONS ?????
 
-- _ingest_origdatablock_metadata()  if not pid.startswith(self.__bid) EXCEPTIONS tests ?
 
 - in _ingest_attachment_metadata() if not pid.startswith(self.__bid)  EXCEPTIONS tests ?
 
@@ -117,9 +127,12 @@ Tests for  scingestor/datasetIngestor.py
 - in ingest() if  pid is None: tests?
 - in ingest() if  dbstatus is None : tests?
 
+
 - in reingest() if self.__ingest_attachment  and pid is None and adss and adss[0]:  tests
 
+
 - in check_list()  if reingest and Exception test ??? (timestamp not float)
+
 
 - clear_tmpfile() if os.path.exists() : tests
 
@@ -191,7 +204,7 @@ scingestor/__init__.py              1      0   100%
 scingestor/beamtimeWatcher.py     358     29    92%   221-222, 263-265, 280, 283, 299-302, 360-361, 453-454, 470-476, 483, 512-514, 516-520
 scingestor/configuration.py        10      0   100%
 scingestor/datasetIngest.py       156      4    97%   271-272, 292-293
-scingestor/datasetIngestor.py     829     72    91%   769-770, 772-780, 795, 804-806, 824, 857, 864-868, 870-872, 924, 948-953, 977-981, 997, 1014, 1045, 1076-1079, 1081, 1086-1087, 1099, 1137-1139, 1165-1169, 1196-1200, 1223-1224, 1246-1250, 1266-1267, 1287, 1291, 1320, 1322-1323, 1342, 1375, 1427, 1455, 1460, 1607, 1621, 1627, 1670-1671, 1690
+scingestor/datasetIngestor.py     829     66    92%   769-770, 772-780, 795, 804-806, 824, 857, 864-868, 870-872, 948-951, 977-981, 997, 1014, 1045, 1076-1079, 1081, 1086-1087, 1099, 1137-1139, 1165-1169, 1196-1200, 1223-1224, 1246-1250, 1266-1267, 1287, 1292, 1321, 1323-1324, 1376, 1428, 1456, 1461, 1608, 1671-1672, 1691
 scingestor/datasetWatcher.py      152     31    80%   155-156, 175-176, 192-193, 202, 221-223, 232-234, 237-249, 264-266, 280-282, 286-288
 scingestor/logger.py               36      0   100%
 scingestor/modelIngest.py          97      0   100%
@@ -199,4 +212,4 @@ scingestor/pathConverter.py        30      0   100%
 scingestor/safeINotifier.py       102      2    98%   229-230
 scingestor/scanDirWatcher.py      184     24    87%   197-198, 240-241, 283, 311-318, 329-337, 343-344, 351-357, 359-360
 -------------------------------------------------------------
-TOTAL                            1955    162    92%
+TOTAL                            1955    156    92%

--- a/test/TODO
+++ b/test/TODO
@@ -91,7 +91,7 @@ Tests for  scingestor/datasetIngestor.py
 
 - in _get_delete_origdatablock(...) exception test if request EXCEPTIONS ?????
 
-- in _get_pid(...) exception test if metedata is not loadable ??
+- in _get_pid(...) exception test if metedata is not loadable or no "pid" in metadata ??
 
 - in _ingest_rawdataset_metadata() if mt["proposalId"] != self.__bid error (wrong beamtime)
 
@@ -148,19 +148,13 @@ Tests for  scingestor/datasetWatcher.py
 - in run() loop self.__ingestor.ingest(scan, token) EXCEPTION test ??
 
 
-
-Tests for  scingestor/modelIngest.py
--------------------------------------
-
-- in _ingest_model(self, metadata, token) last return  ??
-
-
 Tests for  scingestor/safeINotifier.py
 --------------------------------------
 
 - in run  os.close(self.__notifier) exception ????
 
 - in _remove()   inotifyx.rm_watch() raise Exception ?? random
+
 
 Tests for  scingestor/scanDirWatcher.py
 ---------------------------------------
@@ -200,9 +194,9 @@ scingestor/datasetIngest.py       156      4    97%   271-272, 292-293
 scingestor/datasetIngestor.py     829     72    91%   769-770, 772-780, 795, 804-806, 824, 857, 864-868, 870-872, 924, 948-953, 977-981, 997, 1014, 1045, 1076-1079, 1081, 1086-1087, 1099, 1137-1139, 1165-1169, 1196-1200, 1223-1224, 1246-1250, 1266-1267, 1287, 1291, 1320, 1322-1323, 1342, 1375, 1427, 1455, 1460, 1607, 1621, 1627, 1670-1671, 1690
 scingestor/datasetWatcher.py      152     31    80%   155-156, 175-176, 192-193, 202, 221-223, 232-234, 237-249, 264-266, 280-282, 286-288
 scingestor/logger.py               36      0   100%
-scingestor/modelIngest.py          98      1    99%   166
+scingestor/modelIngest.py          97      0   100%
 scingestor/pathConverter.py        30      0   100%
-scingestor/safeINotifier.py       102      4    96%   157-158, 229-230
+scingestor/safeINotifier.py       102      2    98%   229-230
 scingestor/scanDirWatcher.py      184     24    87%   197-198, 240-241, 283, 311-318, 329-337, 343-344, 351-357, 359-360
 -------------------------------------------------------------
-TOTAL                            1956    165    92%
+TOTAL                            1955    162    92%


### PR DESCRIPTION
It resolves #223 by adding tests and checks to not ingest an attachment when the corresponding dataset pid is missing